### PR TITLE
Remove unused Procfile CNB entry from `heroku/builder:22`

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -9,13 +9,8 @@ run-image = "heroku/heroku:22-cnb"
 version = "0.14.0"
 
 [[buildpacks]]
-  id = "heroku/procfile"
-  uri = "docker://docker.io/heroku/procfile-cnb:1.0.1"
-
-[[buildpacks]]
   id = "heroku/nodejs"
   uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:99e2db8060d12bd5967157c08bfd0f9d2c7fee9f5c2da872c472a9f82b822930"
-
 
 [[buildpacks]]
   id = "heroku/nodejs-function"


### PR DESCRIPTION
Explicitly listing the Procfile CNB is only required for shimmed CNBs, since the native CNBs list it in their meta-buildpack.

As such this `[[buildpacks]]` asset entry is not required, since the procfile buildpack is not listed in the top-level `[[order]]` definition.

GUS-W-11263169.