### PR TITLE
Use version `0.0.0` for shimmed buildpacks

### DIFF
--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -30,15 +30,15 @@ version = "0.14.0"
 
 [[buildpacks]]
   id = "heroku/python"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.3.1&name=Python"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.0.0&name=Python"
 
 [[buildpacks]]
   id = "heroku/php"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.3.1&name=PHP"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.0.0&name=PHP"
 
 [[buildpacks]]
   id = "heroku/go"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.3.1&name=Go"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.0.0&name=Go"
 
 [[buildpacks]]
   id = "heroku/nodejs"
@@ -61,7 +61,7 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/python"
-    version = "0.3.1"
+    version = "0.0.0"
 
   [[order.group]]
     id = "heroku/procfile"
@@ -81,7 +81,7 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/php"
-    version = "0.3.1"
+    version = "0.0.0"
 
   [[order.group]]
     id = "heroku/procfile"
@@ -91,7 +91,7 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/go"
-    version = "0.3.1"
+    version = "0.0.0"
 
   [[order.group]]
     id = "heroku/procfile"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -30,15 +30,15 @@ version = "0.14.0"
 
 [[buildpacks]]
   id = "heroku/python"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.3.1&name=Python"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.0.0&name=Python"
 
 [[buildpacks]]
   id = "heroku/php"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.3.1&name=PHP"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.0.0&name=PHP"
 
 [[buildpacks]]
   id = "heroku/go"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.3.1&name=Go"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.0.0&name=Go"
 
 [[buildpacks]]
   id = "heroku/nodejs"
@@ -62,7 +62,7 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/python"
-    version = "0.3.1"
+    version = "0.0.0"
 
   [[order.group]]
     id = "heroku/procfile"
@@ -82,7 +82,7 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/php"
-    version = "0.3.1"
+    version = "0.0.0"
 
   [[order.group]]
     id = "heroku/procfile"
@@ -92,7 +92,7 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/go"
-    version = "0.3.1"
+    version = "0.0.0"
 
   [[order.group]]
     id = "heroku/procfile"


### PR DESCRIPTION
Since we don't properly manage this version anyway and to align with `heroku/builder:22`, this PR changes the CNB version of all shimmed buildpacks to `0.0.0`.