### PR TITLE
Update JVM buildpacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ workflows:
           matrix:
             alias: test-getting-started-guides-22
             parameters:
-              language: ["node-js", "typescript"]
+              language: ["java", "node-js", "typescript"]
           requires:
             - create-builder-22
       - test-example:
@@ -200,7 +200,7 @@ workflows:
           matrix:
             alias: test-examples-22
             parameters:
-              example: ["javascriptfunctionscaffold", "typescriptfunctionscaffold"]
+              example: ["javafunctionscaffold", "javascriptfunctionscaffold", "typescriptfunctionscaffold"]
           requires:
             - create-builder-22
       - publish-builder:

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -16,6 +16,14 @@ version = "0.14.0"
   id = "heroku/nodejs-function"
   uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:7c7e4453ff62639bd2044001c0f504092c53ecff5b3a720adef7866611e5dea7"
 
+[[buildpacks]]
+  id = "heroku/java"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e3031bc05816379243c5f732e4acb4345f7c968977b91bae0e40dd954894b87e"
+
+[[buildpacks]]
+  id = "heroku/java-function"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:bd64e489115813777d8723f04944a98fcf7993329d55db6c6c80a9b1c05599d0"
+
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
@@ -25,3 +33,13 @@ version = "0.14.0"
   [[order.group]]
     id = "heroku/nodejs"
     version = "0.5.4"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/java-function"
+    version = "0.3.31"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/java"
+    version = "0.6.0"

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -10,7 +10,7 @@ version = "0.14.0"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:06938365d0bb9c2b9e3d54b50331161541a4666e2fdb14b4880c9ae95d07b2b7"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e3031bc05816379243c5f732e4acb4345f7c968977b91bae0e40dd954894b87e"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.14.0"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:c913b5581cd8a935058f680e6de6b7d9fe66237c379dfddd24c2267c3f41c9ba"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:bd64e489115813777d8723f04944a98fcf7993329d55db6c6c80a9b1c05599d0"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -106,7 +106,7 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.30"
+    version = "0.3.31"
 
 [[order]]
   [[order.group]]
@@ -116,4 +116,4 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.5.0"
+    version = "0.6.0"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -10,7 +10,7 @@ version = "0.14.0"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:06938365d0bb9c2b9e3d54b50331161541a4666e2fdb14b4880c9ae95d07b2b7"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e3031bc05816379243c5f732e4acb4345f7c968977b91bae0e40dd954894b87e"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.14.0"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:c913b5581cd8a935058f680e6de6b7d9fe66237c379dfddd24c2267c3f41c9ba"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:bd64e489115813777d8723f04944a98fcf7993329d55db6c6c80a9b1c05599d0"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -107,7 +107,7 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.30"
+    version = "0.3.31"
 
 [[order]]
   [[order.group]]
@@ -117,4 +117,4 @@ version = "0.14.0"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.5.0"
+    version = "0.6.0"


### PR DESCRIPTION
## `heroku/java` `0.6.0`

* Upgraded `heroku/maven` to `1.0.1`
* Upgraded `heroku/jvm` to `1.0.1`

### Breaking
* Remove Gradle support from this meta-buildpack. Gradle support was realized by using a shimmed version of the `heroku/gradle` Heroku buildpack. We decided to strictly separate shimmed buildpacks from proper CNBs. Gradle support will be re-added later, using a native CNB. ([#308](https://github.com/heroku/buildpacks-jvm/pull/308))

## `heroku/java-function` `0.3.31`

* Upgraded `heroku/jvm-function-invoker` to `0.6.2`
* Upgraded `heroku/maven` to `1.0.1`
* Upgraded `heroku/jvm` to `1.0.1`

## `heroku/jvm` `1.0.1`

* Add support for the `heroku-22` stack. ([#304](https://github.com/heroku/buildpacks-jvm/pull/304))
* [Azul Zulu Builds of OpenJDK](https://www.azul.com/downloads/?package=jdk#download-openjdk) is now the default OpenJDK distribution. This change does not affect the `heroku-18` and `heroku-20` stack. ([#304](https://github.com/heroku/buildpacks-jvm/pull/304))

## `heroku/maven` `1.0.1`

* Add support for the `heroku-22` stack. ([#304](https://github.com/heroku/buildpacks-jvm/pull/304))

## `heroku/jvm-function-invoker` `0.6.2`

* Upgrade `libcnb` to `0.6.0` and `libherokubuildpack` to `0.6.0`.
* Add support for the `heroku-22` stack. ([#304](https://github.com/heroku/buildpacks-jvm/pull/304))