### PR TITLE
Remove retrying of `pack builder create`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,16 +16,7 @@ jobs:
           version: 0.26.0
       - attach_workspace:
           at: /tmp/workspace
-      - run:
-          name: Create builder with retries
-          command: |
-            n=1
-            until [ "$n" -ge 5 ]
-            do
-              pack builder create << parameters.builder-dir >> --config << parameters.builder-dir >>/builder.toml --pull-policy always && break
-              n=$((n + 1))
-              sleep $(($n * 2))
-            done
+      - run: pack builder create << parameters.builder-dir >> --config << parameters.builder-dir >>/builder.toml --pull-policy always
       - run: docker save << parameters.builder-dir >> | zstd > /tmp/workspace/<< parameters.builder-dir >>.tar.zst
       - persist_to_workspace:
           root: /tmp/workspace


### PR DESCRIPTION
Since:
- The retry handling is broken, such that if the command fails after three retries, then the exit code is obscured and the CI run continues to the next step. This causes a confusing error message that's shown instead of the actual error.
- In the case of legitimate failures, the retries prolong the time until the CI result shows the failure.
- The builder creation step is pretty reliable now (I've inspected several dozen invocations and didn't see any failures).
- If we start seeing intermittency in the future, I would rather know about it so we can improve reliability for everyone, rather than cover it up via retries.

GUS-W-11263169.