### PR TITLE
Bump java-function and nodejs-function

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -14,7 +14,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:648d2f31d90e277d377fd26667a7f5abbd84f00bed37a4a2fb4bc5a061eb1f21"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:83e823f6bf0a03fc07407cd4057c7b487c66b1f0aed1cbba83573d1d5de017e6"
 
 [[buildpacks]]
   id = "heroku/java"
@@ -22,12 +22,12 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:bd64e489115813777d8723f04944a98fcf7993329d55db6c6c80a9b1c05599d0"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f97f45a9c605435547411479c61d2def2a92a42e5015e8356db431e18776cd1a"
 
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.9.5"
+    version = "0.9.6"
 
 [[order]]
   [[order.group]]
@@ -37,7 +37,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.31"
+    version = "0.3.32"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -18,7 +18,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:bd64e489115813777d8723f04944a98fcf7993329d55db6c6c80a9b1c05599d0"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f97f45a9c605435547411479c61d2def2a92a42e5015e8356db431e18776cd1a"
 
 [[buildpacks]]
   id = "heroku/gradle"
@@ -50,7 +50,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:648d2f31d90e277d377fd26667a7f5abbd84f00bed37a4a2fb4bc5a061eb1f21"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:83e823f6bf0a03fc07407cd4057c7b487c66b1f0aed1cbba83573d1d5de017e6"
 
 [[order]]
   [[order.group]]
@@ -105,12 +105,12 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.9.5"
+    version = "0.9.6"
 
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.31"
+    version = "0.3.32"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -18,7 +18,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:bd64e489115813777d8723f04944a98fcf7993329d55db6c6c80a9b1c05599d0"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f97f45a9c605435547411479c61d2def2a92a42e5015e8356db431e18776cd1a"
 
 [[buildpacks]]
   id = "heroku/gradle"
@@ -50,7 +50,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:648d2f31d90e277d377fd26667a7f5abbd84f00bed37a4a2fb4bc5a061eb1f21"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:83e823f6bf0a03fc07407cd4057c7b487c66b1f0aed1cbba83573d1d5de017e6"
 
 
 [[order]]
@@ -106,12 +106,12 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.9.5"
+    version = "0.9.6"
 
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.31"
+    version = "0.3.32"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
## `heroku/java-function` `0.3.32`

* Upgraded `heroku/jvm-function-invoker` to `0.6.3`

## `heroku/jvm-function-invoker` `0.6.3`

* Upgrade `libcnb` to `0.8.0` and `libherokubuildpack` to `0.8.0`
* Updated `java function runtime` to `1.0.7`

## `heroku/nodejs-function` `0.9.6`

* Upgraded `heroku/nodejs-function-invoker` to `0.3.2`

## `heroku/nodejs-function-invoker` to `0.3.2`

* Updated `nodejs function runtime` to `0.11.2`

