### PR TITLE
 Update suggested stack to heroku-22

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ builders that enable Heroku-like builds with the [`pack`](https://github.com/bui
 | Builder Image                                       | Base Image                                  | Status     |
 |-----------------------------------------------------|---------------------------------------------|------------|
 | [`heroku/buildpacks:18`][buildpacks-tags]           | [`heroku/heroku:18-cnb-build`][heroku-tags] | Deprecated |
-| [`heroku/buildpacks:20`][buildpacks-tags]           | [`heroku/heroku:20-cnb-build`][heroku-tags] | Suggested  |
-| [`heroku/builder:22`][builder-tags]                 | [`heroku/heroku:22-cnb-build`][heroku-tags] | Available  |
+| [`heroku/buildpacks:20`][buildpacks-tags]           | [`heroku/heroku:20-cnb-build`][heroku-tags] | Available  |
+| [`heroku/builder:22`][builder-tags]                 | [`heroku/heroku:22-cnb-build`][heroku-tags] | Suggested  |
 | [`heroku/builder-classic:22`][builder-classic-tags] | [`heroku/heroku:22-cnb-build`][heroku-tags] | Available  |
 
 [`heroku/builder`][builder-tags] builder images feature Heroku's native Cloud Native Buildpacks. These buildpacks are optimized and make use of many CNB features.


### PR DESCRIPTION
The heroku-22 stack will soon be the default stack, suggest it.

GUS-W-11639040.