### PR TITLE
Add `heroku/jvm` `1.0.3` to all builders

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -18,11 +18,11 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:cb4757bcaf4da69d45931b164297dd32e39bdac0636a5ab1be01b0a502b6457f"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:7fdca04c10eb4cab060b6e8f49b9e7420c51e95ce983c57beaba4cc7278d13b2"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f0b285a99116ab20a0cdb9c6c4f60dcd98867cf4be2c416813d13148d0bdaf15"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:d269fe5610ea6789e015b8e22ee37e7e245f53ea1cae130d83a45d89310e043f"
 
 [[order]]
   [[order.group]]
@@ -37,11 +37,9 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.34"
-
+    version = "0.3.35"
 
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.2"
-    
+    version = "0.6.3"

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -10,7 +10,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:cb4757bcaf4da69d45931b164297dd32e39bdac0636a5ab1be01b0a502b6457f"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:7fdca04c10eb4cab060b6e8f49b9e7420c51e95ce983c57beaba4cc7278d13b2"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f0b285a99116ab20a0cdb9c6c4f60dcd98867cf4be2c416813d13148d0bdaf15"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:d269fe5610ea6789e015b8e22ee37e7e245f53ea1cae130d83a45d89310e043f"
 
 [[buildpacks]]
   id = "heroku/gradle"
@@ -110,7 +110,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.34"
+    version = "0.3.35"
 
 [[order]]
   [[order.group]]
@@ -120,7 +120,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.2"
+    version = "0.6.3"
 
 # heroku/java previously supported Gradle by mixing in the shimmed heroku/gradle buildpack. When we decided to make a
 # clean cut and not have shimmed buildpacks in the CNB repository, support for Gradle in heroku/java was dropped.
@@ -129,7 +129,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.0.2"
+    version = "1.0.3"
 
   [[order.group]]
     id = "heroku/gradle"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -10,7 +10,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:cb4757bcaf4da69d45931b164297dd32e39bdac0636a5ab1be01b0a502b6457f"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:7fdca04c10eb4cab060b6e8f49b9e7420c51e95ce983c57beaba4cc7278d13b2"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:f0b285a99116ab20a0cdb9c6c4f60dcd98867cf4be2c416813d13148d0bdaf15"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:d269fe5610ea6789e015b8e22ee37e7e245f53ea1cae130d83a45d89310e043f"
 
 [[buildpacks]]
   id = "heroku/gradle"
@@ -111,7 +111,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.34"
+    version = "0.3.35"
 
 [[order]]
   [[order.group]]
@@ -121,7 +121,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.2"
+    version = "0.6.3"
 
 # heroku/java previously supported Gradle by mixing in the shimmed heroku/gradle buildpack. When we decided to make a
 # clean cut and not have shimmed buildpacks in the CNB repository, support for Gradle in heroku/java was dropped.
@@ -130,7 +130,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.0.2"
+    version = "1.0.3"
 
   [[order.group]]
     id = "heroku/gradle"


### PR DESCRIPTION
## `heroku/jvm` `1.0.3`

* Default version for **OpenJDK 8** is now `1.8.0_345`
* Default version for **OpenJDK 11** is now `11.0.16.1`
* Default version for **OpenJDK 17** is now `17.0.4.1`

## `heroku/java` `0.6.3`

* Upgraded `heroku/jvm` to `1.0.3`

## `heroku/java-function` `0.3.35`

* Upgraded `heroku/jvm` to `1.0.3`

Closes GUS-W-11665960