### PR TITLE
CI: Increase retries when connecting to the test servers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
       - run:
           name: Test web server response
           command: |
-            if curl -sSf --retry 5 --retry-delay 1 --retry-all-errors --connect-timeout 3 http://localhost:8080 -o response.txt; then
+            if curl -sSf --retry 10 --retry-delay 1 --retry-all-errors --connect-timeout 3 http://localhost:8080 -o response.txt; then
               echo "Successful response from server"
             else
               echo "Server did not respond successfully"
@@ -84,7 +84,7 @@ jobs:
       - run:
           name: Test function response
           command: |
-            if curl -sSf --retry 5 --retry-delay 1 --retry-all-errors --connect-timeout 3 -X POST -H 'x-health-check: true' http://localhost:8080 -o response.txt; then
+            if curl -sSf --retry 10 --retry-delay 1 --retry-all-errors --connect-timeout 3 -X POST -H 'x-health-check: true' http://localhost:8080 -o response.txt; then
               echo "Successful response from function"
             else
               echo "Function did not respond successfully"


### PR DESCRIPTION
The classic Java/Clojure CNB smoke tests are currently intermittently failing when trying to connect to the test app's server.

For example:
https://app.circleci.com/pipelines/github/heroku/builder/2046/workflows/d4255ddd-02cf-4fa6-b421-32e2f0cc22ba/jobs/47191
https://app.circleci.com/pipelines/github/heroku/builder/2044/workflows/54069379-9662-4bc7-b403-396799d953b2/jobs/47100
https://app.circleci.com/pipelines/github/heroku/builder/2044/workflows/54069379-9662-4bc7-b403-396799d953b2/jobs/47099
https://app.circleci.com/pipelines/github/heroku/builder/2043/workflows/6b5225ef-a290-4ddb-b53d-e7c529cc2dd2/jobs/47039
https://app.circleci.com/pipelines/github/heroku/builder/2042/workflows/ded5beb9-3e48-4101-9b5a-2da05e499dfe/jobs/47003
https://app.circleci.com/pipelines/github/heroku/builder/2041/workflows/248b9d3a-3a57-41be-bf5a-3f27cbff8ed7/jobs/46943
https://app.circleci.com/pipelines/github/heroku/builder/2040/workflows/b5c97e8f-fdb3-4d04-bd0c-7b996b2f6697/jobs/46911
https://app.circleci.com/pipelines/github/heroku/builder/2039/workflows/48743978-841c-41ea-95f6-990d7c0f6e74/jobs/46862
https://app.circleci.com/pipelines/github/heroku/builder/2038/workflows/512466b7-90d0-44be-bfe0-0f079c337088/jobs/46791

The logs appear to show the server booting successfully, but there was not a successful response within the six attempts to connect.

Inspecting a passing CI run shows that even when the test passes, it routinely takes 5 attempts before the server has booted and returns a successful response. For example:
https://app.circleci.com/pipelines/github/heroku/builder/2038/workflows/512466b7-90d0-44be-bfe0-0f079c337088/jobs/46797
https://app.circleci.com/pipelines/github/heroku/builder/2046/workflows/d4255ddd-02cf-4fa6-b421-32e2f0cc22ba/jobs/47189

As such, these failures are likely just from running on a slightly slower host, that causes the boot time to extend just over the retry threshold - and we can resolve these failures by increasing the retry count.

GUS-W-11815096.