### PR TITLE
Use shimmed Ruby buildpack instead of the prototype hybrid CNB

### DIFF
--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -26,7 +26,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/ruby"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/ruby?version=0.0.0&name=Ruby"
 
 [[buildpacks]]
   id = "heroku/procfile"
@@ -55,7 +55,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/ruby"
-    version = "0.1.3"
+    version = "0.0.0"
 
   [[order.group]]
     id = "heroku/procfile"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -26,7 +26,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/ruby"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-ruby-buildpack@sha256:3eeb3773cdbd29d4fb0d578f7781fe8c525de73593480e2740b7143262e5bef5"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/ruby?version=0.0.0&name=Ruby"
 
 [[buildpacks]]
   id = "heroku/procfile"
@@ -56,7 +56,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/ruby"
-    version = "0.1.3"
+    version = "0.0.0"
 
   [[order.group]]
     id = "heroku/procfile"


### PR DESCRIPTION
The previously deployed Ruby buildpack is based on the "hybrid" approach https://github.com/heroku/heroku-buildpack-ruby. Essentially Terence added support for CNB into the existing buildpack. This works, but it's not taking advantage of most of the features in CNB. It's really not too different than using the "shim" buildpack.

(The *shim* is a wrapper around any legacy/v2 buildpack that allows it to interface with CNB)

The idea is that we'll use the shim buildpack for now and switch over once a native CNB implementation in Rust is ready.

GUS-W-11461073