### PR TITLE
Bump Java and Node.js buildpacks

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -10,7 +10,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:790fbb9845160b604a53a164515789a76cc48796dfeb470e2a697ddaf27cb5fe"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:5bf17a46c97809dd85cde6b1dee431117c06118c4ab8af8ca72ed52fb2369814"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -32,7 +32,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.5.8"
+    version = "0.5.9"
 
 [[order]]
   [[order.group]]

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -14,7 +14,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:bdab746cca0e189b02c851d90e39d8367c16d897c21b7248ae30b2993cdfafb1"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:ca27ed30a77ca62a3ab5d233034edf71669d79823b72f9e5fc71e9c1bc0c927d"
 
 [[buildpacks]]
   id = "heroku/java"
@@ -27,7 +27,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.9.9"
+    version = "0.9.10"
 
 [[order]]
   [[order.group]]

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -22,7 +22,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:d269fe5610ea6789e015b8e22ee37e7e245f53ea1cae130d83a45d89310e043f"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:05db69b29422852362aa3b8ba06cd33a0e0930f2f037ec52baf268f99d03965f"
 
 [[order]]
   [[order.group]]
@@ -37,7 +37,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.35"
+    version = "0.3.36"
 
 [[order]]
   [[order.group]]

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -18,7 +18,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:7fdca04c10eb4cab060b6e8f49b9e7420c51e95ce983c57beaba4cc7278d13b2"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e33188188acb8631ccd1ee9fbd7eb7314b1a4aad4b3ecf0072b3bab23839012e"
 
 [[buildpacks]]
   id = "heroku/java-function"
@@ -42,4 +42,4 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.3"
+    version = "0.6.4"

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -129,7 +129,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.0.3"
+    version = "1.0.4"
 
   [[order.group]]
     id = "heroku/gradle"

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -46,7 +46,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:790fbb9845160b604a53a164515789a76cc48796dfeb470e2a697ddaf27cb5fe"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:5bf17a46c97809dd85cde6b1dee431117c06118c4ab8af8ca72ed52fb2369814"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -115,7 +115,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.5.8"
+    version = "0.5.9"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -10,7 +10,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:7fdca04c10eb4cab060b6e8f49b9e7420c51e95ce983c57beaba4cc7278d13b2"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e33188188acb8631ccd1ee9fbd7eb7314b1a4aad4b3ecf0072b3bab23839012e"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -120,7 +120,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.3"
+    version = "0.6.4"
 
 # heroku/java previously supported Gradle by mixing in the shimmed heroku/gradle buildpack. When we decided to make a
 # clean cut and not have shimmed buildpacks in the CNB repository, support for Gradle in heroku/java was dropped.

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -18,7 +18,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:d269fe5610ea6789e015b8e22ee37e7e245f53ea1cae130d83a45d89310e043f"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:05db69b29422852362aa3b8ba06cd33a0e0930f2f037ec52baf268f99d03965f"
 
 [[buildpacks]]
   id = "heroku/gradle"
@@ -110,7 +110,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.35"
+    version = "0.3.36"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -50,7 +50,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:bdab746cca0e189b02c851d90e39d8367c16d897c21b7248ae30b2993cdfafb1"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:ca27ed30a77ca62a3ab5d233034edf71669d79823b72f9e5fc71e9c1bc0c927d"
 
 [[order]]
   [[order.group]]
@@ -105,7 +105,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.9.9"
+    version = "0.9.10"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -10,7 +10,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:7fdca04c10eb4cab060b6e8f49b9e7420c51e95ce983c57beaba4cc7278d13b2"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e33188188acb8631ccd1ee9fbd7eb7314b1a4aad4b3ecf0072b3bab23839012e"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -121,7 +121,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.3"
+    version = "0.6.4"
 
 # heroku/java previously supported Gradle by mixing in the shimmed heroku/gradle buildpack. When we decided to make a
 # clean cut and not have shimmed buildpacks in the CNB repository, support for Gradle in heroku/java was dropped.

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -130,7 +130,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.0.3"
+    version = "1.0.4"
 
   [[order.group]]
     id = "heroku/gradle"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -18,7 +18,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:d269fe5610ea6789e015b8e22ee37e7e245f53ea1cae130d83a45d89310e043f"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:05db69b29422852362aa3b8ba06cd33a0e0930f2f037ec52baf268f99d03965f"
 
 [[buildpacks]]
   id = "heroku/gradle"
@@ -111,7 +111,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.35"
+    version = "0.3.36"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -50,7 +50,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:bdab746cca0e189b02c851d90e39d8367c16d897c21b7248ae30b2993cdfafb1"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:ca27ed30a77ca62a3ab5d233034edf71669d79823b72f9e5fc71e9c1bc0c927d"
 
 
 [[order]]
@@ -106,7 +106,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.9.9"
+    version = "0.9.10"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -46,7 +46,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:790fbb9845160b604a53a164515789a76cc48796dfeb470e2a697ddaf27cb5fe"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:5bf17a46c97809dd85cde6b1dee431117c06118c4ab8af8ca72ed52fb2369814"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -116,7 +116,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.5.8"
+    version = "0.5.9"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
This bumps the Java and Node.js buildpacks. The highlights include 
- https://github.com/heroku/buildpacks-nodejs/pull/352
- https://github.com/heroku/buildpacks-nodejs/pull/358
- https://github.com/heroku/buildpacks-jvm/pull/374
- https://github.com/heroku/buildpacks-jvm/pull/372
- https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/400
- https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/417
- https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/402
- https://github.com/forcedotcom/sf-fx-runtime-nodejs/pull/401
- https://github.com/forcedotcom/sf-fx-runtime-java/pull/339
- https://github.com/forcedotcom/sf-fx-runtime-java/pull/316
- https://github.com/forcedotcom/sf-fx-runtime-java/pull/314

Check the relevant changelogs for details:

https://github.com/heroku/buildpacks-nodejs
https://github.com/heroku/buildpacks-jvm

[W-11543492](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE000013CyjtYAC)