### PR TITLE
Update publish job conditional

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -119,7 +119,7 @@ jobs:
 
   publish:
     runs-on: ubuntu-22.04
-    if: github.branch == 'main'
+    if: success() && github.ref == 'refs/heads/main'
     needs:
       - test-guides
       - test-examples


### PR DESCRIPTION
The publish part of the GitHub action is not triggering (see here: https://github.com/heroku/builder/actions/runs/3176302715/jobs/5175517309). This should fix it.

Context:
https://github.com/heroku/builder/pull/286#issuecomment-1265887581