### PR TITLE
JVM buildpacks updates

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -18,11 +18,11 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e33188188acb8631ccd1ee9fbd7eb7314b1a4aad4b3ecf0072b3bab23839012e"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:b5fb470e12507e2a2dfa48e74648bd8e9c6adc5ae70e6145fb3871d782a8e2bb"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:05db69b29422852362aa3b8ba06cd33a0e0930f2f037ec52baf268f99d03965f"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:1472bec7148ea9797904da9eca7f85d158b8886017d7fc1e19803e83a507facf"
 
 [[order]]
   [[order.group]]
@@ -37,9 +37,9 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.36"
+    version = "0.3.37"
 
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.4"
+    version = "0.6.5"

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -10,7 +10,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e33188188acb8631ccd1ee9fbd7eb7314b1a4aad4b3ecf0072b3bab23839012e"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:b5fb470e12507e2a2dfa48e74648bd8e9c6adc5ae70e6145fb3871d782a8e2bb"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:05db69b29422852362aa3b8ba06cd33a0e0930f2f037ec52baf268f99d03965f"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:1472bec7148ea9797904da9eca7f85d158b8886017d7fc1e19803e83a507facf"
 
 [[buildpacks]]
   id = "heroku/gradle"
@@ -110,7 +110,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.36"
+    version = "0.3.37"
 
 [[order]]
   [[order.group]]
@@ -120,7 +120,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.4"
+    version = "0.6.5"
 
 # heroku/java previously supported Gradle by mixing in the shimmed heroku/gradle buildpack. When we decided to make a
 # clean cut and not have shimmed buildpacks in the CNB repository, support for Gradle in heroku/java was dropped.
@@ -129,7 +129,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.0.4"
+    version = "1.0.5"
 
   [[order.group]]
     id = "heroku/gradle"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -10,7 +10,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:e33188188acb8631ccd1ee9fbd7eb7314b1a4aad4b3ecf0072b3bab23839012e"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:b5fb470e12507e2a2dfa48e74648bd8e9c6adc5ae70e6145fb3871d782a8e2bb"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:05db69b29422852362aa3b8ba06cd33a0e0930f2f037ec52baf268f99d03965f"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:1472bec7148ea9797904da9eca7f85d158b8886017d7fc1e19803e83a507facf"
 
 [[buildpacks]]
   id = "heroku/gradle"
@@ -111,7 +111,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.36"
+    version = "0.3.37"
 
 [[order]]
   [[order.group]]
@@ -121,7 +121,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.4"
+    version = "0.6.5"
 
 # heroku/java previously supported Gradle by mixing in the shimmed heroku/gradle buildpack. When we decided to make a
 # clean cut and not have shimmed buildpacks in the CNB repository, support for Gradle in heroku/java was dropped.
@@ -130,7 +130,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.0.4"
+    version = "1.0.5"
 
   [[order.group]]
     id = "heroku/gradle"


### PR DESCRIPTION
## `heroku/jvm` `1.0.5`

* Default version for **OpenJDK 8** is now `1.8.0_352`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
* Default version for **OpenJDK 11** is now `11.0.17`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
* Default version for **OpenJDK 13** is now `13.0.13`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
* Default version for **OpenJDK 15** is now `15.0.9`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
* Default version for **OpenJDK 17** is now `17.0.5`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
* Default version for **OpenJDK 19** is now `19.0.1`. ([#387](https://github.com/heroku/buildpacks-jvm/pull/387))
* Upgrade `libcnb` and `libherokubuildpack` to `0.11.1`. ([#384](https://github.com/heroku/buildpacks-jvm/pull/384) and [#386](https://github.com/heroku/buildpacks-jvm/pull/386))

## `heroku/jvm-function-invoker` `0.6.5`

* Updated function runtime to `1.1.1`. ([#388](https://github.com/heroku/buildpacks-jvm/pull/388))
* Upgrade `libcnb` and `libherokubuildpack` to `0.11.1`. ([#384](https://github.com/heroku/buildpacks-jvm/pull/384) and [#386](https://github.com/heroku/buildpacks-jvm/pull/386))

## `heroku/java` `0.6.5`

* Upgraded `heroku/jvm` to `1.0.5`

## `heroku/java-function` `0.3.37`

* Upgraded `heroku/jvm-function-invoker` to `0.6.5`
* Upgraded `heroku/jvm` to `1.0.5`