### PR TITLE
Fix publish process for heroku/builder-classic:22

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -134,7 +134,7 @@ jobs:
             tag_alias: heroku/buildpacks:latest
             tag_private: heroku-20:builder
           - builder: builder-classic-22
-            public_tag: heroku/builder-classic:22
+            tag_public: heroku/builder-classic:22
           - builder: builder-22
             tag_public: heroku/builder:22
             tag_private: heroku-22:builder


### PR DESCRIPTION
The heroku/builder-classic:22 images on Docker Hub haven't been updated since 2022-10-03: https://hub.docker.com/r/heroku/builder-classic/tags. This was the date this project cutover to GitHub Actions. 

We were using the wrong argument key for this image only.

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00001BCzI3YAL/view)