### PR TITLE
Bump Node.js Buildpacks

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -14,7 +14,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:39a374ea1ae66ae11072661ce0e634f4265e366551c418521de457fc8efb8239"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:2c60923e9efbe0670227ca574c786ef15ad8b244f2d729c0220d7f76d7b52370"
 
 [[buildpacks]]
   id = "heroku/java"
@@ -27,7 +27,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.9.12"
+    version = "0.9.13"
 
 [[order]]
   [[order.group]]

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -10,7 +10,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:5bf17a46c97809dd85cde6b1dee431117c06118c4ab8af8ca72ed52fb2369814"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:71488d3d2bfba4681c999f8614a5347bf77bb861ddc9a49b019a6e42a60457e5"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -32,7 +32,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.5.9"
+    version = "0.5.10"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -50,7 +50,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:39a374ea1ae66ae11072661ce0e634f4265e366551c418521de457fc8efb8239"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:2c60923e9efbe0670227ca574c786ef15ad8b244f2d729c0220d7f76d7b52370"
 
 [[order]]
   [[order.group]]
@@ -105,7 +105,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.9.12"
+    version = "0.9.13"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -46,7 +46,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:5bf17a46c97809dd85cde6b1dee431117c06118c4ab8af8ca72ed52fb2369814"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:71488d3d2bfba4681c999f8614a5347bf77bb861ddc9a49b019a6e42a60457e5"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -115,7 +115,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.5.9"
+    version = "0.5.10"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -50,7 +50,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:39a374ea1ae66ae11072661ce0e634f4265e366551c418521de457fc8efb8239"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:2c60923e9efbe0670227ca574c786ef15ad8b244f2d729c0220d7f76d7b52370"
 
 
 [[order]]
@@ -106,7 +106,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.9.12"
+    version = "0.9.13"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -46,7 +46,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:5bf17a46c97809dd85cde6b1dee431117c06118c4ab8af8ca72ed52fb2369814"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:71488d3d2bfba4681c999f8614a5347bf77bb861ddc9a49b019a6e42a60457e5"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -116,7 +116,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.5.9"
+    version = "0.5.10"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
This brings in https://github.com/heroku/buildpacks-nodejs/pull/386 for heroku/nodejs and heroku/nodejs-function. It also brings in some new Node.js versions (like Node.js 19.0.0 and 18.12.0, 18.11.0, 18.10.0, 16.18.0) for heroku/nodejs.

[W-11932999](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE000019GHxdYAG)
[W-11985938](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00001B8AjcYAF)