### PR TITLE
Revert "Update lifecycle from v0.14.1 to v0.15.0"

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:22-cnb-build"
 run-image = "heroku/heroku:22-cnb"
 
 [lifecycle]
-version = "0.15.0"
+version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"

--- a/builder-classic-22/builder.toml
+++ b/builder-classic-22/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:22-cnb-build"
 run-image = "heroku/heroku:22-cnb"
 
 [lifecycle]
-version = "0.15.0"
+version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/clojure"

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:18-cnb-build"
 run-image = "heroku/heroku:18-cnb"
 
 [lifecycle]
-version = "0.15.0"
+version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:20-cnb-build"
 run-image = "heroku/heroku:20-cnb"
 
 [lifecycle]
-version = "0.15.0"
+version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"


### PR DESCRIPTION
Reverts #294 due to #295, which has been reported upstream at:
https://github.com/buildpacks/lifecycle/issues/945

Closes #295.
GUS-W-11995402.