### PR TITLE
Switch the Python function example to installing from PyPI

### DIFF
--- a/examples/python-function/requirements.txt
+++ b/examples/python-function/requirements.txt
@@ -1,5 +1,1 @@
-# Once Python support for Salesforce Functions is in beta, the salesforce-functions
-# package will be published to PyPI, and the GitHub URL here can be replaced by the
-# PyPI package name instead. For example:
-# salesforce-functions>=0.1.0,<0.2.0
-salesforce-functions @ git+https://github.com/heroku/sf-functions-python.git
+salesforce-functions>=0.1.0,<1.0.0


### PR DESCRIPTION
Now that the `salesforce-functions` package is published to PyPI, the example fixture used in CI should install from PyPI instead of directly from the package's GitHub repository.

GUS-W-12397284.