### PR TITLE
Update lifecycle from v0.14.1 to v0.15.3

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:22-cnb-build"
 run-image = "heroku/heroku:22-cnb"
 
 [lifecycle]
-version = "0.14.1"
+version = "0.15.3"
 
 [[buildpacks]]
   id = "heroku/python-functions-experimental"

--- a/builder-classic-22/builder.toml
+++ b/builder-classic-22/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:22-cnb-build"
 run-image = "heroku/heroku:22-cnb"
 
 [lifecycle]
-version = "0.14.1"
+version = "0.15.3"
 
 [[buildpacks]]
   id = "heroku/clojure"

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:18-cnb-build"
 run-image = "heroku/heroku:18-cnb"
 
 [lifecycle]
-version = "0.14.1"
+version = "0.15.3"
 
 [[buildpacks]]
   id = "heroku/java"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:20-cnb-build"
 run-image = "heroku/heroku:20-cnb"
 
 [lifecycle]
-version = "0.14.1"
+version = "0.15.3"
 
 [[buildpacks]]
   id = "heroku/java"


### PR DESCRIPTION
Release notes:
https://github.com/buildpacks/lifecycle/releases/tag/v0.14.2
https://github.com/buildpacks/lifecycle/releases/tag/v0.14.3
https://github.com/buildpacks/lifecycle/releases/tag/v0.15.0
https://github.com/buildpacks/lifecycle/releases/tag/v0.15.1
https://github.com/buildpacks/lifecycle/releases/tag/v0.15.2
https://github.com/buildpacks/lifecycle/releases/tag/v0.15.3

Commits:
https://github.com/buildpacks/lifecycle/compare/v0.14.1...v0.15.3

Of note, this resolves the issue seen in v0.15.0 which resulted in the previous upgrade having to be reverted. See:
https://github.com/heroku/builder/issues/295
https://github.com/heroku/builder/pull/296
https://github.com/buildpacks/lifecycle/issues/945
https://github.com/buildpacks/lifecycle/pull/946

GUS-W-12037750.