### PR TITLE
Update default OpenJDK versions for Q1 2023 releases

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -22,11 +22,11 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:b5fb470e12507e2a2dfa48e74648bd8e9c6adc5ae70e6145fb3871d782a8e2bb"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:3de6f9431995a029deaa6bcec60b7c539eb6f2cefbaf82a740e8c1117431390b"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:46e353cadcd941baeb0f566d7ab7b1f13c18e96223c1143dc51b258638ab9d47"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:9a7dcb2a02621f1df0ce2c0ed9954a656c9a5a2027fe3f46c7af6e41b50b5448"
 
 [[buildpacks]]
   id = "heroku/go"
@@ -54,12 +54,12 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.38"
+    version = "0.3.39"
 
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.5"
+    version = "0.6.6"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -10,7 +10,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:b5fb470e12507e2a2dfa48e74648bd8e9c6adc5ae70e6145fb3871d782a8e2bb"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:3de6f9431995a029deaa6bcec60b7c539eb6f2cefbaf82a740e8c1117431390b"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:46e353cadcd941baeb0f566d7ab7b1f13c18e96223c1143dc51b258638ab9d47"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:9a7dcb2a02621f1df0ce2c0ed9954a656c9a5a2027fe3f46c7af6e41b50b5448"
 
 [[buildpacks]]
   id = "heroku/gradle"
@@ -110,7 +110,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.38"
+    version = "0.3.39"
 
 [[order]]
   [[order.group]]
@@ -120,7 +120,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.5"
+    version = "0.6.6"
 
 # heroku/java previously supported Gradle by mixing in the shimmed heroku/gradle buildpack. When we decided to make a
 # clean cut and not have shimmed buildpacks in the CNB repository, support for Gradle in heroku/java was dropped.
@@ -129,7 +129,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.0.5"
+    version = "1.0.6"
 
   [[order.group]]
     id = "heroku/gradle"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -10,7 +10,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:b5fb470e12507e2a2dfa48e74648bd8e9c6adc5ae70e6145fb3871d782a8e2bb"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:3de6f9431995a029deaa6bcec60b7c539eb6f2cefbaf82a740e8c1117431390b"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -18,7 +18,7 @@ version = "0.14.1"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:46e353cadcd941baeb0f566d7ab7b1f13c18e96223c1143dc51b258638ab9d47"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:9a7dcb2a02621f1df0ce2c0ed9954a656c9a5a2027fe3f46c7af6e41b50b5448"
 
 [[buildpacks]]
   id = "heroku/gradle"
@@ -111,7 +111,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.38"
+    version = "0.3.39"
 
 [[order]]
   [[order.group]]
@@ -121,7 +121,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.5"
+    version = "0.6.6"
 
 # heroku/java previously supported Gradle by mixing in the shimmed heroku/gradle buildpack. When we decided to make a
 # clean cut and not have shimmed buildpacks in the CNB repository, support for Gradle in heroku/java was dropped.
@@ -130,7 +130,7 @@ version = "0.14.1"
 [[order]]
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.0.5"
+    version = "1.0.6"
 
   [[order.group]]
     id = "heroku/gradle"


### PR DESCRIPTION
## `heroku/jvm` `1.0.6`

* Default version for **OpenJDK 8** is now `1.8.0_362`. ([#413](https://github.com/heroku/buildpacks-jvm/pull/413))
* Default version for **OpenJDK 11** is now `11.0.18`. ([#413](https://github.com/heroku/buildpacks-jvm/pull/413))
* Default version for **OpenJDK 13** is now `13.0.14`. ([#413](https://github.com/heroku/buildpacks-jvm/pull/413))
* Default version for **OpenJDK 15** is now `15.0.10`. ([#413](https://github.com/heroku/buildpacks-jvm/pull/413))
* Default version for **OpenJDK 17** is now `17.0.6`. ([#413](https://github.com/heroku/buildpacks-jvm/pull/413))
* Default version for **OpenJDK 19** is now `19.0.2`. ([#413](https://github.com/heroku/buildpacks-jvm/pull/413))

## `heroku/java` `0.6.6`

* Upgraded `heroku/jvm` to `1.0.6`

## `heroku/java-function` `0.3.39`

* Upgraded `heroku/jvm` to `1.0.6`

Ref: GUS-W-12396535