### PR TITLE
Update lifecycle from v0.15.3 to v0.16.0

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -73,7 +73,7 @@ jobs:
           BUILDER: ${{ matrix.builder }}
         run: docker pull heroku/heroku:${BUILDER##*-}-cnb
       - name: Build getting started guide image
-        run: pack build getting-started --builder ${{ matrix.builder }} --pull-policy never --verbose
+        run: pack build getting-started --builder ${{ matrix.builder }} --pull-policy never
       - name: Start getting started guide image
         run: docker run --name getting-started --detach -p 8080:8080 --env PORT=8080 getting-started
       - name: Test getting started web server response
@@ -114,7 +114,7 @@ jobs:
         env:
           BUILDER: ${{ matrix.builder }}
         run: docker pull heroku/heroku:${BUILDER##*-}-cnb
-      - run: pack build example-function --path examples/${{ matrix.example }} --builder ${{ matrix.builder }} --pull-policy never --verbose
+      - run: pack build example-function --path examples/${{ matrix.example }} --builder ${{ matrix.builder }} --pull-policy never
       - run: docker run --name example-function --detach -p 8080:8080 --env PORT=8080 example-function
       - name: Test example function web server response
         run: |

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:22-cnb-build"
 run-image = "heroku/heroku:22-cnb"
 
 [lifecycle]
-version = "0.15.3"
+version = "0.16.0"
 
 [[buildpacks]]
   id = "heroku/python-functions-experimental"

--- a/builder-classic-22/builder.toml
+++ b/builder-classic-22/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:22-cnb-build"
 run-image = "heroku/heroku:22-cnb"
 
 [lifecycle]
-version = "0.15.3"
+version = "0.16.0"
 
 [[buildpacks]]
   id = "heroku/clojure"

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:18-cnb-build"
 run-image = "heroku/heroku:18-cnb"
 
 [lifecycle]
-version = "0.15.3"
+version = "0.16.0"
 
 [[buildpacks]]
   id = "heroku/java"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:20-cnb-build"
 run-image = "heroku/heroku:20-cnb"
 
 [lifecycle]
-version = "0.15.3"
+version = "0.16.0"
 
 [[buildpacks]]
   id = "heroku/java"


### PR DESCRIPTION
To pick up recent fixes/features, including an improvement to the build log output in the case where all buildpacks fail to detect. With those build log improvements the `--verbose` option to `pack build` is no longer required in CI here, and has been removed to make the rest of the logs less noisy.

This update also does bring with it a new deprecation warning for usages of old buildpack and platform API versions. These are currently triggered by buildpacks using the cnb-shim, however, they are just warnings and should be resolved separately rather than here, to avoid adding additional risk to this change.

See:
https://github.com/buildpacks/lifecycle/releases/tag/v0.16.0
https://github.com/buildpacks/lifecycle/compare/v0.15.3...v0.16.0

GUS-W-12538046.