### PR TITLE
Add heroku/python to builder:22

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -38,21 +38,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["buildpacks-18", "buildpacks-20", "builder-classic-22"]
+        builder: ["buildpacks-18", "buildpacks-20", builder-22, "builder-classic-22"]
         language: ["go", "gradle", "java", "node-js", "php", "python", "ruby", "scala", "typescript"]
         include:
           - builder: builder-classic-22
             language: clojure
+        exclude:
           - builder: builder-22
-            language: go
+            language: gradle
           - builder: builder-22
-            language: java
+            language: php
           - builder: builder-22
-            language: node-js
-          - builder: builder-22
-            language: typescript
-          - builder: builder-22
-            language: ruby
+            language: scala
     steps:
       - uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ builders that enable Heroku-like builds with the [`pack`](https://github.com/bui
 | [`heroku/builder:22`][builder-tags]                 | [`heroku/heroku:22-cnb-build`][heroku-tags] | Suggested  |
 | [`heroku/builder-classic:22`][builder-classic-tags] | [`heroku/heroku:22-cnb-build`][heroku-tags] | Available  |
 
-[`heroku/builder`][builder-tags] builder images feature Heroku's native Cloud Native Buildpacks. These buildpacks are optimized and make use of many CNB features. These builder images support Go, Java, Ruby, Node.js, and Typescript codebases.
+[`heroku/builder`][builder-tags] builder images feature Heroku's native Cloud Native Buildpacks. These buildpacks are optimized and make use of many CNB features. These builder images support Go, Java, Node.js, Python, Ruby, and Typescript codebases.
 
 [`heroku/builder-classic`][builder-classic-tags] builder images feature Heroku's classic platform buildpacks, shimmed for compatibility with the Cloud Native Buildpacks specification. These buildpacks don't take advantage of many CNB features and are less optimized, but offer a wider variety of languages and legacy language feature support.These builder images support Clojure, Go, Gradle, Java, Node.js, PHP, Python, Ruby, Scala, and Typescript codebases.
 

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -9,8 +9,8 @@ run-image = "heroku/heroku:22-cnb"
 version = "0.16.0"
 
 [[buildpacks]]
-  id = "heroku/python-functions-experimental"
-  uri = "https://heroku-buildpack-python.s3.us-east-1.amazonaws.com/cnb/python-functions-experimental-0.1.0.cnb"
+  id = "heroku/python"
+  uri = "docker://docker.io/heroku/buildpack-python@sha256:cca54fd8d41699273d258a12d5312aafdf52409e0a51536e22194c3873a2359e"
 
 [[buildpacks]]
   id = "heroku/nodejs"
@@ -42,6 +42,15 @@ version = "0.16.0"
 
 [[order]]
   [[order.group]]
+    id = "heroku/python"
+    version = "0.1.0"
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "2.0.0"
+    optional = true
+
+[[order]]
+  [[order.group]]
     id = "heroku/nodejs-engine"
     version = "0.8.16"
     optional = true
@@ -60,11 +69,6 @@ version = "0.16.0"
     id = "heroku/procfile"
     version = "2.0.0"
     optional = true
-
-[[order]]
-  [[order.group]]
-    id = "heroku/python-functions-experimental"
-    version = "0.1.0"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
The initial implementation of a native (non-[shimmed](https://github.com/heroku/cnb-shim)) [libcnb.rs](https://github.com/heroku/libcnb.rs)-based Python CNB.

Improving parity with the classic buildpack is tracked via: https://github.com/heroku/buildpacks-python/issues

The `builder:22` CI getting started matrix config has been switched from opt-in to opt-out, since more languages are now supported than unsupported.

GUS-W-12614533.