### PR TITLE
Downgrade node guide test to v16 for heroku-18 stack

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -55,6 +55,9 @@ jobs:
         with:
           ref: main
           repository: heroku/${{ matrix.language }}-getting-started.git
+      - name: Modify package.json (fix for Heroku-18 stack)
+        if: matrix.language == 'node-js' && matrix.builder == 'buildpacks-18'
+        run: sed -i 's/18.x || 16.x/16.x/g' package.json
       - uses: buildpacks/github-actions/setup-pack@v5.0.1
       - name: Setup builder cache
         uses: actions/cache@v3


### PR DESCRIPTION
The [node-js-getting started guide](https://github.com/heroku/node-js-getting-started) should be compatible with both Node 16.x and 18.x but the Heroku-18 stack only supports Node 16.x.  This change adds an conditional step to the test workflow to downgrade the engine specified in `package.json` from `18.x || 16.x` to just `16.x`.

See:
https://github.com/heroku/node-js-getting-started/pull/294#discussion_r1127817002

GUS-W-12652981.