### PR TITLE
Update heroku/go, heroku/nodejs

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -52,11 +52,11 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-engine"
-    version = "0.8.16"
+    version = "0.8.17"
     optional = true
   [[order.group]]
     id = "heroku/nodejs-yarn"
-    version = "0.4.0"
+    version = "0.4.1"
     optional = true
   [[order.group]]
     id = "heroku/jvm"

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -14,7 +14,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:c7771cf6501bd2c05653951a1ee24155d2dd695a36e4c2c8391ff1581b2708c3"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:98797014462325ce3016e3e1a5c02fa345c4a13da0400d5ee3bd6a8b9e322db3"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -78,7 +78,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.6.0"
+    version = "0.6.1"
 
 [[order]]
   [[order.group]]

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -30,7 +30,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/go"
-  uri = "docker://docker.io/heroku/buildpack-go@sha256:be8222c2ba29871324f79e4e2aa0d3d1990c310f0e12c8ea296507ffac7d7705"
+  uri = "docker://docker.io/heroku/buildpack-go@sha256:043cd538baa5f1414ac58871a32c41c5017bc4ab4c694ceb73ea10138338a4de"
 
 [[buildpacks]]
   id = "heroku/ruby"
@@ -93,7 +93,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/go"
-    version = "0.1.2"
+    version = "0.1.3"
   [[order.group]]
     id = "heroku/procfile"
     version = "2.0.0"

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -52,7 +52,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-engine"
-    version = "0.8.17"
+    version = "0.8.18"
     optional = true
   [[order.group]]
     id = "heroku/nodejs-yarn"

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -18,7 +18,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:03d8b2e7f0330f23ffa0cdbcb878b234cd3d4223f58649190f22c6c07a650b42"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:7a2ac52f6eadbd4757abd78a37fb88f9b03d3316b91f9a80eeb78c7d433d0413"
 
 [[buildpacks]]
   id = "heroku/java"
@@ -73,7 +73,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.10.0"
+    version = "0.10.1"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -46,7 +46,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:c7771cf6501bd2c05653951a1ee24155d2dd695a36e4c2c8391ff1581b2708c3"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:98797014462325ce3016e3e1a5c02fa345c4a13da0400d5ee3bd6a8b9e322db3"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -115,7 +115,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.6.0"
+    version = "0.6.1"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -50,7 +50,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:03d8b2e7f0330f23ffa0cdbcb878b234cd3d4223f58649190f22c6c07a650b42"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:7a2ac52f6eadbd4757abd78a37fb88f9b03d3316b91f9a80eeb78c7d433d0413"
 
 [[order]]
   [[order.group]]
@@ -105,7 +105,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.10.0"
+    version = "0.10.1"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -46,7 +46,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:c7771cf6501bd2c05653951a1ee24155d2dd695a36e4c2c8391ff1581b2708c3"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:98797014462325ce3016e3e1a5c02fa345c4a13da0400d5ee3bd6a8b9e322db3"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -116,7 +116,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.6.0"
+    version = "0.6.1"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -50,7 +50,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:03d8b2e7f0330f23ffa0cdbcb878b234cd3d4223f58649190f22c6c07a650b42"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:7a2ac52f6eadbd4757abd78a37fb88f9b03d3316b91f9a80eeb78c7d433d0413"
 
 
 [[order]]
@@ -106,7 +106,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.10.0"
+    version = "0.10.1"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
This brings in the latest language versions for Node.js and Go.