### PR TITLE
Update to latest heroku/nodejs

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -14,7 +14,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:98797014462325ce3016e3e1a5c02fa345c4a13da0400d5ee3bd6a8b9e322db3"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:183beffff0ea2bacb0244904a31d1d74e8f9786ea697f03618d3ea627e8b5820"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -78,7 +78,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.6.1"
+    version = "0.6.2"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -46,7 +46,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:98797014462325ce3016e3e1a5c02fa345c4a13da0400d5ee3bd6a8b9e322db3"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:183beffff0ea2bacb0244904a31d1d74e8f9786ea697f03618d3ea627e8b5820"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -115,7 +115,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.6.1"
+    version = "0.6.2"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -46,7 +46,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:98797014462325ce3016e3e1a5c02fa345c4a13da0400d5ee3bd6a8b9e322db3"
+  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:183beffff0ea2bacb0244904a31d1d74e8f9786ea697f03618d3ea627e8b5820"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -116,7 +116,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.6.1"
+    version = "0.6.2"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
Brings in node.js 18.16.0!

Changelog: https://github.com/heroku/buildpacks-nodejs/blob/main/meta-buildpacks/nodejs/CHANGELOG.md#062-20230417

