### PR TITLE
Pin the buildpack versions in `heroku/buildpacks:18`

### DIFF
--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -14,7 +14,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/scala"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/scala?version=0.0.0&name=Scala"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/scala-v96?id=heroku/scala&name=Scala&version=0.0.0&stacks=heroku-18"
 
 [[buildpacks]]
   id = "heroku/java-function"
@@ -22,11 +22,11 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/gradle"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle?version=0.0.0&name=Gradle"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle-v39?id=heroku/gradle&name=Gradle&version=0.0.0&stacks=heroku-18"
 
 [[buildpacks]]
   id = "heroku/ruby"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/ruby?version=0.0.0&name=Ruby"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/ruby-v271?id=heroku/ruby&name=Ruby&version=0.0.0&stacks=heroku-18"
 
 [[buildpacks]]
   id = "heroku/procfile"
@@ -34,15 +34,15 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/python"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.0.0&name=Python"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/python-v232?id=heroku/python&name=Python&version=0.0.0&stacks=heroku-18"
 
 [[buildpacks]]
   id = "heroku/php"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.0.0&name=PHP"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php-v230?id=heroku/php&name=PHP&version=0.0.0&stacks=heroku-18"
 
 [[buildpacks]]
   id = "heroku/go"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.0.0&name=Go"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go-v173?id=heroku/go&name=Go&version=0.0.0&stacks=heroku-18"
 
 [[buildpacks]]
   id = "heroku/nodejs"


### PR DESCRIPTION
Since the `heroku/buildpacks:18` CNB builder image is based upon the Heroku-18 stack, which [has reached end-of-life](https://devcenter.heroku.com/changelog-items/2583), and as such support will soon be removed from the stack from our various buildpacks.

We will soon be stopping the publishing of `heroku/buildpacks:18` image updates entirely, however, we expect a few more upstream security updates to Ubuntu 18.04 (until 31st May, Canonical's revised EOL date) which we wish to pick up in the meantime.

By pinning the buildpack versions of our shimmed buildpacks, it unblocks removing Heroku-18 support from them in the meantime.

To pin the version, we rely on the fact that the buildpack registry stores versioned archives of each buildpack release, with a `vNNN` suffix.

However, we also have to:
- Pass an explicit `id` now, to prevent IDs like `heroku/python-v232`
- Pass an explicit `stacks` list due to: heroku/cnb-shim#72

The latest version numbers of each shimmed buildpack were generated using:

```
$ for lang in scala gradle ruby python php go; do echo "${lang}-v$(h buildpacks:versions heroku/${lang} | head -n3 | tail -n1 | cut -d ' ' -f 2)"; done
scala-v96
gradle-v39
ruby-v271
python-v232
php-v230
go-v173
```

GUS-W-13143718.