### PR TITLE
Make Heroku-18 builds fail with a skippable EOL warning

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -73,7 +73,7 @@ jobs:
           BUILDER: ${{ matrix.builder }}
         run: docker pull heroku/heroku:${BUILDER##*-}-cnb
       - name: Build getting started guide image
-        run: pack build getting-started --builder ${{ matrix.builder }} --pull-policy never
+        run: pack build getting-started --builder ${{ matrix.builder }} --pull-policy never --env ALLOW_INSECURE_HEROKU_18_BUILDER=1
       - name: Start getting started guide image
         run: docker run --name getting-started --detach -p 8080:8080 --env PORT=8080 getting-started
       - name: Test getting started web server response
@@ -114,7 +114,7 @@ jobs:
         env:
           BUILDER: ${{ matrix.builder }}
         run: docker pull heroku/heroku:${BUILDER##*-}-cnb
-      - run: pack build example-function --path examples/${{ matrix.example }} --builder ${{ matrix.builder }} --pull-policy never
+      - run: pack build example-function --path examples/${{ matrix.example }} --builder ${{ matrix.builder }} --pull-policy never --env ALLOW_INSECURE_HEROKU_18_BUILDER=1
       - run: docker run --name example-function --detach -p 8080:8080 --env PORT=8080 example-function
       - name: Test example function web server response
         run: |

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 This repository is responsible for building and publishing [Cloud Native Buildpacks](https://buildpacks.io)
 builders that enable Heroku-like builds with the [`pack`](https://github.com/buildpacks/pack) command.
 
-| Builder Image                                       | Base Image                                  | Status     |
-|-----------------------------------------------------|---------------------------------------------|------------|
-| [`heroku/buildpacks:18`][buildpacks-tags]           | [`heroku/heroku:18-cnb-build`][heroku-tags] | Deprecated |
-| [`heroku/buildpacks:20`][buildpacks-tags]           | [`heroku/heroku:20-cnb-build`][heroku-tags] | Available  |
-| [`heroku/builder:22`][builder-tags]                 | [`heroku/heroku:22-cnb-build`][heroku-tags] | Suggested  |
-| [`heroku/builder-classic:22`][builder-classic-tags] | [`heroku/heroku:22-cnb-build`][heroku-tags] | Available  |
+| Builder Image                                       | Base Image                                  | Status      |
+|-----------------------------------------------------|---------------------------------------------|-------------|
+| [`heroku/buildpacks:18`][buildpacks-tags]           | [`heroku/heroku:18-cnb-build`][heroku-tags] | End-of-life |
+| [`heroku/buildpacks:20`][buildpacks-tags]           | [`heroku/heroku:20-cnb-build`][heroku-tags] | Available   |
+| [`heroku/builder:22`][builder-tags]                 | [`heroku/heroku:22-cnb-build`][heroku-tags] | Recommended |
+| [`heroku/builder-classic:22`][builder-classic-tags] | [`heroku/heroku:22-cnb-build`][heroku-tags] | Available   |
 
 [`heroku/builder`][builder-tags] builder images feature Heroku's native Cloud Native Buildpacks. These buildpacks are optimized and make use of many CNB features. These builder images support Go, Java, Node.js, Python, Ruby, and Typescript codebases.
 
@@ -20,7 +20,7 @@ builders that enable Heroku-like builds with the [`pack`](https://github.com/bui
 
 ## Usage
 
-`pack build myapp --builder heroku/buildpacks:20`
+`pack build myapp --builder heroku/builder:22`
 
 ## Deprecated Images
 

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -9,6 +9,10 @@ run-image = "heroku/heroku:18-cnb"
 version = "0.16.1"
 
 [[buildpacks]]
+  id = "heroku/heroku-18-stack-eol-warning"
+  uri = "./end-of-life-buildpack/"
+
+[[buildpacks]]
   id = "heroku/java"
   uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:21990393c93927b16f76c303ae007ea7e95502d52b0317ca773d4cd51e7a5682"
 
@@ -54,6 +58,10 @@ version = "0.16.1"
 
 [[order]]
   [[order.group]]
+    id = "heroku/heroku-18-stack-eol-warning"
+    version = "1.0.0"
+
+  [[order.group]]
     id = "heroku/ruby"
     version = "0.0.0"
 
@@ -63,6 +71,10 @@ version = "0.16.1"
     optional = true
 
 [[order]]
+  [[order.group]]
+    id = "heroku/heroku-18-stack-eol-warning"
+    version = "1.0.0"
+
   [[order.group]]
     id = "heroku/python"
     version = "0.0.0"
@@ -74,6 +86,10 @@ version = "0.16.1"
 
 [[order]]
   [[order.group]]
+    id = "heroku/heroku-18-stack-eol-warning"
+    version = "1.0.0"
+
+  [[order.group]]
     id = "heroku/scala"
     version = "0.0.0"
 
@@ -83,6 +99,10 @@ version = "0.16.1"
     optional = true
 
 [[order]]
+  [[order.group]]
+    id = "heroku/heroku-18-stack-eol-warning"
+    version = "1.0.0"
+
   [[order.group]]
     id = "heroku/php"
     version = "0.0.0"
@@ -94,6 +114,10 @@ version = "0.16.1"
 
 [[order]]
   [[order.group]]
+    id = "heroku/heroku-18-stack-eol-warning"
+    version = "1.0.0"
+
+  [[order.group]]
     id = "heroku/go"
     version = "0.0.0"
 
@@ -104,20 +128,36 @@ version = "0.16.1"
 
 [[order]]
   [[order.group]]
+    id = "heroku/heroku-18-stack-eol-warning"
+    version = "1.0.0"
+
+  [[order.group]]
     id = "heroku/nodejs-function"
     version = "0.10.3"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/heroku-18-stack-eol-warning"
+    version = "1.0.0"
+
   [[order.group]]
     id = "heroku/java-function"
     version = "0.3.43"
 
 [[order]]
   [[order.group]]
+    id = "heroku/heroku-18-stack-eol-warning"
+    version = "1.0.0"
+
+  [[order.group]]
     id = "heroku/nodejs"
     version = "0.6.3"
 
 [[order]]
+  [[order.group]]
+    id = "heroku/heroku-18-stack-eol-warning"
+    version = "1.0.0"
+
   [[order.group]]
     id = "heroku/java"
     version = "0.6.9"
@@ -127,6 +167,10 @@ version = "0.16.1"
 # To maintain backwards compatibilty, we have this order definition here that mirrors what was in heroku/java
 # previously. It can be removed when the heroku/java CNB supports Gradle again.
 [[order]]
+  [[order.group]]
+    id = "heroku/heroku-18-stack-eol-warning"
+    version = "1.0.0"
+
   [[order.group]]
     id = "heroku/jvm"
     version = "1.0.9"

--- a/buildpacks-18/end-of-life-buildpack/bin/build
+++ b/buildpacks-18/end-of-life-buildpack/bin/build
@@ -16,8 +16,8 @@ This builder image (heroku/buildpacks:18) is based upon the Heroku-18
 stack, which has been end-of-life since April 30th, 2023:
 https://devcenter.heroku.com/changelog-items/2583
 
-The underlying Ubuntu 18.04 OS is no longer receiving security updates,
-and so apps still using it could contain security vulnerabilities.
+The underlying Ubuntu 18.04 OS is no longer receiving security updates.
+Apps still using this OS could be vulnerable.
 
 Please switch to one of our newer 'heroku/builder:*' builder images:
 https://github.com/heroku/builder#heroku-builder-images

--- a/buildpacks-18/end-of-life-buildpack/bin/build
+++ b/buildpacks-18/end-of-life-buildpack/bin/build
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ENV_DIR="${2}/env"
+ALLOW_BUILD="$(cat "${ENV_DIR}/ALLOW_INSECURE_HEROKU_18_BUILDER" 2> /dev/null || true)"
+
+function echo_stderr() {
+  local ansi_red="\033[1;31m"
+  local ansi_reset="\033[0m"
+  echo -e "\n${ansi_red}${1}${ansi_reset}\n" >&2
+}
+
+read -r -d '' EOL_MESSAGE <<'EOF' || true
+This builder image (heroku/buildpacks:18) is based upon the Heroku-18
+stack, which has been end-of-life since April 30th, 2023:
+https://devcenter.heroku.com/changelog-items/2583
+
+The underlying Ubuntu 18.04 OS is no longer receiving security updates,
+and so apps still using it could contain security vulnerabilities.
+
+Please switch to one of our newer 'heroku/builder:*' builder images:
+https://github.com/heroku/builder#heroku-builder-images
+
+If you are using the Pack CLI, you will need to adjust the '--builder' CLI
+argument, or else change the default builder configuration:
+https://buildpacks.io/docs/tools/pack/cli/pack_config_default-builder/
+EOF
+
+if [[ "${ALLOW_BUILD}" == "1" ]]; then
+  echo_stderr "Warning: ${EOL_MESSAGE}"
+  exit 0
+else
+  echo_stderr "Error: ${EOL_MESSAGE}"
+  echo_stderr "To ignore this error, set the env var ALLOW_INSECURE_HEROKU_18_BUILDER to 1."
+  exit 1
+fi

--- a/buildpacks-18/end-of-life-buildpack/bin/detect
+++ b/buildpacks-18/end-of-life-buildpack/bin/detect
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+exit 0

--- a/buildpacks-18/end-of-life-buildpack/buildpack.toml
+++ b/buildpacks-18/end-of-life-buildpack/buildpack.toml
@@ -1,0 +1,8 @@
+api = "0.9"
+
+[buildpack]
+  id = "heroku/heroku-18-stack-eol-warning"
+  version = "1.0.0"
+
+[[stacks]]
+  id = "heroku-18"


### PR DESCRIPTION
The Heroku-18 stack reached end-of-life on April 30th 2023, and as of May 1st 2023, builds are no longer possible on the (default) non-CNB Heroku build system, and the underlying stack images will no longer
 receive security updates (beyond whatever updates Canonical choose to
release in May). 

However, anyone using the `heroku/buildpacks:18` CNB builder image may not realise that it's now EOL and soon to be insecure. They may also not realise that the builder image has moved from the `heroku/buildpacks` Docker repo to `heroku/builder`.

In order to raise awareness of both of these, an EOL buildpack has been added, which fails the build with an EOL warning, unless the env var `ALLOW_INSECURE_HEROKU_18_BUILDER` is set to `1` during the build.

This should affect very few users, since Heroku is not yet using CNBs by default, and Salesforce Functions use the `heroku/builder:22` builder image instead.

This buildpack was written in bash, since:
- the buildpack functionality we need is extremely simple (checking an env var, printing a message and exiting 1 or 0)
- the buildpack (and other Heroku-18 related files) are going to be deleted in a few weeks anyway, so its not worth spending time getting a Rust build workflow working with the existing complex GitHub Actions workflow here

GUS-W-13143190.