### PR TITLE
Remove functions buildpacks from older builder images

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -93,11 +93,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["buildpacks-18", "buildpacks-20", "builder-22"]
-        example: ["java-function", "javascript-function", "typescript-function"]
-        include:
-          - builder: builder-22
-            example: python-function
+        builder: ["builder-22"]
+        example: ["java-function", "javascript-function", "python-function", "typescript-function"]
     steps:
       - uses: actions/checkout@v3
       - uses: buildpacks/github-actions/setup-pack@v5.1.0

--- a/buildpacks-18/builder.toml
+++ b/buildpacks-18/builder.toml
@@ -21,10 +21,6 @@ version = "0.16.1"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/scala-v96?id=heroku/scala&name=Scala&version=0.0.0&stacks=heroku-18"
 
 [[buildpacks]]
-  id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:b4750feb3b738786cdbee31146ea9bfb2b63ab124dca2f1605c2ec79ab11e05c"
-
-[[buildpacks]]
   id = "heroku/gradle"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle-v39?id=heroku/gradle&name=Gradle&version=0.0.0&stacks=heroku-18"
 
@@ -51,10 +47,6 @@ version = "0.16.1"
 [[buildpacks]]
   id = "heroku/nodejs"
   uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:e124fd4dcd60460ab8588c1ce0fc07fb07b84b4100d6f03d34daa2ffea097ce8"
-
-[[buildpacks]]
-  id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:467a2fdab78b22f05f6f0d6801ccad0a2cc1c963838df311e1a237aec2bfdc71"
 
 [[order]]
   [[order.group]]
@@ -132,24 +124,6 @@ version = "0.16.1"
     version = "1.0.0"
 
   [[order.group]]
-    id = "heroku/nodejs-function"
-    version = "0.10.4"
-
-[[order]]
-  [[order.group]]
-    id = "heroku/heroku-18-stack-eol-warning"
-    version = "1.0.0"
-
-  [[order.group]]
-    id = "heroku/java-function"
-    version = "0.3.43"
-
-[[order]]
-  [[order.group]]
-    id = "heroku/heroku-18-stack-eol-warning"
-    version = "1.0.0"
-
-  [[order.group]]
     id = "heroku/nodejs"
     version = "0.6.4"
 
@@ -164,7 +138,7 @@ version = "0.16.1"
 
 # heroku/java previously supported Gradle by mixing in the shimmed heroku/gradle buildpack. When we decided to make a
 # clean cut and not have shimmed buildpacks in the CNB repository, support for Gradle in heroku/java was dropped.
-# To maintain backwards compatibilty, we have this order definition here that mirrors what was in heroku/java
+# To maintain backwards compatibility, we have this order definition here that mirrors what was in heroku/java
 # previously. It can be removed when the heroku/java CNB supports Gradle again.
 [[order]]
   [[order.group]]

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -17,10 +17,6 @@ version = "0.16.1"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/scala?version=0.0.0&name=Scala"
 
 [[buildpacks]]
-  id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:b4750feb3b738786cdbee31146ea9bfb2b63ab124dca2f1605c2ec79ab11e05c"
-
-[[buildpacks]]
   id = "heroku/gradle"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle?version=0.0.0&name=Gradle"
 
@@ -47,11 +43,6 @@ version = "0.16.1"
 [[buildpacks]]
   id = "heroku/nodejs"
   uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-buildpack@sha256:e124fd4dcd60460ab8588c1ce0fc07fb07b84b4100d6f03d34daa2ffea097ce8"
-
-[[buildpacks]]
-  id = "heroku/nodejs-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-nodejs-function-buildpack@sha256:467a2fdab78b22f05f6f0d6801ccad0a2cc1c963838df311e1a237aec2bfdc71"
-
 
 [[order]]
   [[order.group]]
@@ -105,16 +96,6 @@ version = "0.16.1"
 
 [[order]]
   [[order.group]]
-    id = "heroku/nodejs-function"
-    version = "0.10.4"
-
-[[order]]
-  [[order.group]]
-    id = "heroku/java-function"
-    version = "0.3.43"
-
-[[order]]
-  [[order.group]]
     id = "heroku/nodejs"
     version = "0.6.4"
 
@@ -125,7 +106,7 @@ version = "0.16.1"
 
 # heroku/java previously supported Gradle by mixing in the shimmed heroku/gradle buildpack. When we decided to make a
 # clean cut and not have shimmed buildpacks in the CNB repository, support for Gradle in heroku/java was dropped.
-# To maintain backwards compatibilty, we have this order definition here that mirrors what was in heroku/java
+# To maintain backwards compatibility, we have this order definition here that mirrors what was in heroku/java
 # previously. It can be removed when the heroku/java CNB supports Gradle again.
 [[order]]
   [[order.group]]


### PR DESCRIPTION
Salesforce Functions switched to using the newer `heroku/builder:22` (Heroku-22) builder image some time ago:
https://developer.salesforce.com/docs/platform/functions/guide/release-notes-intro.html#september-28-2022

As such, the Functions buildpacks in the `heroku/buildpacks:18` and `heroku/buildpacks:20` builder images are now unused.

Removing them:
- means we can reduce the size of the CI workflow for this repository down from 52 jobs to 46 jobs
- reduces the size of these legacy builder images slightly
- means the upstream buildpacks can drop support from their CI matrices too

GUS-W-13183125.