### PR TITLE
Update JVM buildpacks, add Scala buildpack

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -52,8 +52,6 @@ jobs:
             language: gradle
           - builder: builder-22
             language: php
-          - builder: builder-22
-            language: scala
     steps:
       - name: Checkout getting started guide
         uses: actions/checkout@v3

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -22,11 +22,15 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:21990393c93927b16f76c303ae007ea7e95502d52b0317ca773d4cd51e7a5682"
+  uri = "docker://docker.io/heroku/buildpack-java@sha256:c6dd500be06a2a1e764c30359c5dd4f4955a98b572ef3095b2f6115cd8a87c99"
 
 [[buildpacks]]
   id = "heroku/java-function"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-function-buildpack@sha256:b4750feb3b738786cdbee31146ea9bfb2b63ab124dca2f1605c2ec79ab11e05c"
+  uri = "docker://docker.io/heroku/buildpack-java-function@sha256:0cbe71ae6b902997f432927fb1dc841652f9b4c7413afb2bcf6a77b8baa4ad7c"
+
+[[buildpacks]]
+  id = "heroku/scala"
+  uri = "docker://docker.io/heroku/buildpack-scala@sha256:1fc6beaf291dcf1972c621afe3a1b3a80d1bffe8fccb6b0a68bc7f24bf99456a"
 
 [[buildpacks]]
   id = "heroku/go"
@@ -60,7 +64,7 @@ version = "0.16.1"
     optional = true
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.0.9"
+    version = "1.0.10"
     optional = true
   [[order.group]]
     id = "heroku/ruby"
@@ -83,12 +87,17 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/java-function"
-    version = "0.3.43"
+    version = "0.3.44"
 
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.9"
+    version = "0.6.10"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/scala"
+    version = "1.0.0"
 
 [[order]]
   [[order.group]]

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -10,7 +10,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/java"
-  uri = "docker://public.ecr.aws/heroku-buildpacks/heroku-java-buildpack@sha256:21990393c93927b16f76c303ae007ea7e95502d52b0317ca773d4cd51e7a5682"
+  uri = "docker://docker.io/heroku/buildpack-java@sha256:c6dd500be06a2a1e764c30359c5dd4f4955a98b572ef3095b2f6115cd8a87c99"
 
 [[buildpacks]]
   id = "heroku/scala"
@@ -102,7 +102,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/java"
-    version = "0.6.9"
+    version = "0.6.10"
 
 # heroku/java previously supported Gradle by mixing in the shimmed heroku/gradle buildpack. When we decided to make a
 # clean cut and not have shimmed buildpacks in the CNB repository, support for Gradle in heroku/java was dropped.
@@ -111,7 +111,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/jvm"
-    version = "1.0.9"
+    version = "1.0.10"
 
   [[order.group]]
     id = "heroku/gradle"


### PR DESCRIPTION
I added the new Scala buildpack to the `heroku/builder:22` only. I believe this is the strategy we had in mind when we release native CNBs to not break existing users of builders that use shimmed buildpacks.

Note: JVM buildpacks have been moved to Docker Hub.

## Changelog

### `heroku/java`

* Upgraded `heroku/jvm` to `1.0.10`

### `heroku/java-function`

* Upgraded `heroku/jvm` to `1.0.10`
* Upgraded `heroku/jvm-function-invoker` to `0.6.8`

### `heroku/jvm`

* Upgrade `libcnb` and `libherokubuildpack` to `0.12.0`. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
* The buildpack now implements Buildpack API 0.9 instead of 0.8, and so requires `lifecycle` 0.15.x or newer. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))

### `heroku/maven`

* Upgrade `libcnb` and `libherokubuildpack` to `0.12.0`. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
* The buildpack now implements Buildpack API 0.9 instead of 0.8, and so requires `lifecycle` 0.15.x or newer. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))

### `heroku/jvm-function-invoker`

* Upgrade `libcnb` and `libherokubuildpack` to `0.12.0`. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
* The buildpack now implements Buildpack API 0.9 instead of 0.8, and so requires `lifecycle` 0.15.x or newer. ([#463](https://github.com/heroku/buildpacks-jvm/pull/463))
