### PR TITLE
Update to Pack 0.29.0

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -24,6 +24,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.1.0
+        with:
+          pack-version: "0.29.0"
       - name: Create builder image
         run: pack builder create ${{ matrix.builder }} --config ${{ matrix.builder }}/builder.toml --pull-policy always
       # We export the run image too (and not just the generated builder image), since it adds virtually
@@ -72,6 +74,8 @@ jobs:
         run: sed -i 's/18.x || 16.x/16.x/g' package.json
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.1.0
+        with:
+          pack-version: "0.29.0"
       - name: Restore Docker images from the cache
         uses: actions/cache/restore@v3
         with:
@@ -107,6 +111,8 @@ jobs:
         uses: actions/checkout@v3
       - name: Install Pack CLI
         uses: buildpacks/github-actions/setup-pack@v5.1.0
+        with:
+          pack-version: "0.29.0"
       - name: Restore Docker images from the cache
         uses: actions/cache/restore@v3
         with:


### PR DESCRIPTION
Since it contains the fix for:
https://github.com/buildpacks/pack/issues/1453

...which will mean we no longer constantly publish new builder images even if nothing has changed. (Since now the SHA256 will stay the same each time, causing the docker push to be a no-op.)

Full release notes:
https://github.com/buildpacks/pack/releases/tag/v0.29.0

Normally we'd wait for the default Pack version to be updated in the `buildpacks/github-actions/setup-pack` Action, however, it hasn't been updated yet:
https://github.com/buildpacks/github-actions/pull/196#issuecomment-1536796572

Once the default version is updated again, we can switch back to using it (and having Dependabot keep the Action up to date), instead of having to hardcode versions here.

GUS-W-13204219.