### PR TITLE
Stop publishing the `heroku/buildpacks:latest` tag

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -142,7 +142,6 @@ jobs:
         include:
           - builder: buildpacks-20
             tag_public: heroku/buildpacks:20
-            tag_alias: heroku/buildpacks:latest
             tag_private: heroku-20:builder
           - builder: builder-classic-22
             tag_public: heroku/builder-classic:22
@@ -168,7 +167,7 @@ jobs:
           if [[ -n "${{ matrix.tag_private }}" ]]; then
             export TAG_PRIVATE="${{ secrets.REGISTRY_HOST }}/s/${{ secrets.SERVICE_TOKEN_USER_NAME }}/${{ matrix.tag_private }}"
           fi
-          export TAGS=($TAG_PRIVATE ${{ matrix.tag_public }} ${{ matrix.tag_alias }})
+          export TAGS=($TAG_PRIVATE ${{ matrix.tag_public }})
           for tag in ${TAGS[@]}; do
             echo "Pushing $tag"
             docker tag ${{ matrix.builder }} $tag


### PR DESCRIPTION
Since:
- It's not documented, or used by anything on our side.
- The `heroku/buildpacks` namespace is deprecated, so calling anything to do with it "latest" seems like it could confuse users.
- We don't publish `latest` for the new `heroku/builder` namespace either (which is probably the best decision for now, given that having such a tag means people could receive breaking changes with no notice).

I will delete the `latest` tag from Docker Hub once this is merged.

GUS-W-13213079.