### PR TITLE
Update Node.js Buildpacks to the latest versions.

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -60,7 +60,7 @@ version = "0.16.1"
     optional = true
   [[order.group]]
     id = "heroku/nodejs-yarn"
-    version = "0.4.3"
+    version = "0.4.4"
     optional = true
   [[order.group]]
     id = "heroku/jvm"

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -14,7 +14,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:22ec91eebee2271b99368844f193c4bb3c6084201062f89b3e45179b938c3241"
+  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:370b3b537642fa35553298ea61119e85fd1ecd6153009611a2fc4d784b26fb92"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
@@ -82,7 +82,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.6.5"
+    version = "0.6.7"
 
 [[order]]
   [[order.group]]

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -18,7 +18,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/nodejs-function"
-  uri = "docker://docker.io/heroku/buildpack-nodejs-function@sha256:12cd3941f3676e98ebee8beb6a46b0ab81dfff87dd0d1de255a74c42bd6b8e6a"
+  uri = "docker://docker.io/heroku/buildpack-nodejs-function@sha256:f338c522db5645afc69c269df479ec622cb0ece5d7b5bdb1b96e696393f2e76b"
 
 [[buildpacks]]
   id = "heroku/java"
@@ -77,7 +77,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-function"
-    version = "0.10.5"
+    version = "0.10.7"
 
 [[order]]
   [[order.group]]

--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -56,7 +56,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs-engine"
-    version = "0.8.22"
+    version = "0.8.24"
     optional = true
   [[order.group]]
     id = "heroku/nodejs-yarn"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -42,7 +42,7 @@ version = "0.16.1"
 
 [[buildpacks]]
   id = "heroku/nodejs"
-  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:22ec91eebee2271b99368844f193c4bb3c6084201062f89b3e45179b938c3241"
+  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:370b3b537642fa35553298ea61119e85fd1ecd6153009611a2fc4d784b26fb92"
 
 [[order]]
   [[order.group]]
@@ -97,7 +97,7 @@ version = "0.16.1"
 [[order]]
   [[order.group]]
     id = "heroku/nodejs"
-    version = "0.6.5"
+    version = "0.6.7"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
The buidpack changes include:

- New Node.js versions
- Bumps to buildpack API 0.9
- Dropped support for the deprecated `heroku-18` stack.