### PR TITLE
Improve the UX for GHA cache restore timeout errors

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -72,8 +72,11 @@ jobs:
       - name: Restore Docker images from the cache
         uses: actions/cache/restore@v3
         with:
+          fail-on-cache-miss: true
           key: ${{ github.run_id}}-${{ matrix.builder }}
           path: images.tar.zst
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
       - name: Load Docker images into the Docker daemon
         run: zstd -dc --long=31 images.tar.zst | docker load
       - name: Build getting started guide image
@@ -109,8 +112,11 @@ jobs:
       - name: Restore Docker images from the cache
         uses: actions/cache/restore@v3
         with:
+          fail-on-cache-miss: true
           key: ${{ github.run_id}}-${{ matrix.builder }}
           path: images.tar.zst
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
       - name: Load Docker images into the Docker daemon
         run: zstd -dc --long=31 images.tar.zst | docker load
       - name: Build example function image
@@ -150,8 +156,11 @@ jobs:
       - name: Restore Docker images from the cache
         uses: actions/cache/restore@v3
         with:
+          fail-on-cache-miss: true
           key: ${{ github.run_id}}-${{ matrix.builder }}
           path: images.tar.zst
+        env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 1
       - name: Load Docker images into the Docker daemon
         run: zstd -dc --long=31 images.tar.zst | docker load
       - name: Log into Docker Hub


### PR DESCRIPTION
Previously if any of the cache restore steps failed due to a timeout, the restore step would only emit a warning, such as:

```
...
Received 130023424 of 337339345 (38.5%), 1.2 MBs/sec
Warning: Failed to restore: The operation cannot be completed in timeout.
Cache not found for input keys: 5424698109-builder-classic-22
```

...and then the job would continue on to the Docker load step, which would fail with:

```
zstd: can't stat images.tar.zst : No such file or directory -- ignored
open /var/lib/docker/tmp/docker-import-4200725306/repositories: no such file or directory
Error: Process completed with exit code 1.
```

For example:
https://github.com/heroku/builder/actions/runs/5424698109/jobs/9864456202#step:5:7

Now:
* If the cache cannot be restored, the cache restore step itself will correctly fail (since we need the restored images; it's not technically a cache - see code comments for why we're not using artifacts).
* The timeout has also been reduced from 10 minutes to 1 minute, so the job fails (and can be retried) sooner. (The cache restore normally takes ~5 seconds.)

GUS-W-13704339.