### PR TITLE
Update lifecycle from v0.16.1 to v0.17.0

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:22-cnb-build"
 run-image = "heroku/heroku:22-cnb"
 
 [lifecycle]
-version = "0.16.1"
+version = "0.17.0"
 
 [[buildpacks]]
   id = "heroku/python"

--- a/builder-classic-22/builder.toml
+++ b/builder-classic-22/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:22-cnb-build"
 run-image = "heroku/heroku:22-cnb"
 
 [lifecycle]
-version = "0.16.1"
+version = "0.17.0"
 
 [[buildpacks]]
   id = "heroku/clojure"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -6,7 +6,7 @@ build-image = "heroku/heroku:20-cnb-build"
 run-image = "heroku/heroku:20-cnb"
 
 [lifecycle]
-version = "0.16.1"
+version = "0.17.0"
 
 [[buildpacks]]
   id = "heroku/java"


### PR DESCRIPTION
Of note, this adds support for Platform API 0.12 and Buildpack API 0.10 (ready for when the Heroku CNB build system and CNBs support them):
https://github.com/buildpacks/spec/releases/tag/platform%2Fv0.12
https://github.com/buildpacks/spec/releases/tag/buildpack%2Fv0.10

Release notes:
https://github.com/buildpacks/lifecycle/releases/tag/v0.16.2
https://github.com/buildpacks/lifecycle/releases/tag/v0.16.3
https://github.com/buildpacks/lifecycle/releases/tag/v0.16.4
https://github.com/buildpacks/lifecycle/releases/tag/v0.16.5
https://github.com/buildpacks/lifecycle/releases/tag/v0.17.0

Commits:
https://github.com/buildpacks/lifecycle/compare/v0.16.1...v0.17.0

GUS-W-13977966.