### PR TITLE
Set the `DYNO` env var when running integration tests

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -75,7 +75,9 @@ jobs:
       - name: Build getting started guide image
         run: pack build getting-started --builder ${{ matrix.builder }} --trust-builder --pull-policy never
       - name: Start getting started guide image
-        run: docker run --name getting-started --detach -p 8080:8080 --env PORT=8080 getting-started
+        # The `DYNO` env var is set to more accurately reflect the Heroku environment, since some of the getting
+        # started guides use the presence of `DYNO` to determine whether to enable production mode or not.
+        run: docker run --name getting-started --detach -p 8080:8080 --env PORT=8080 --env DYNO=web.1 getting-started
       - name: Test getting started web server response
         run: |
           if curl -sSf --retry 10 --retry-delay 1 --retry-all-errors --connect-timeout 3 http://localhost:8080 -o response.txt; then
@@ -113,7 +115,7 @@ jobs:
       - name: Build example function image
         run: pack build example-function --path examples/functions/${{ matrix.language }} --builder ${{ matrix.builder }} --trust-builder --pull-policy never
       - name: Start example function image
-        run: docker run --name example-function --detach -p 8080:8080 --env PORT=8080 example-function
+        run: docker run --name example-function --detach -p 8080:8080 --env PORT=8080 --env DYNO=web.1 example-function
       - name: Test example function web server response
         run: |
           if curl -sSf --retry 10 --retry-delay 1 --retry-all-errors --connect-timeout 3 -X POST -H 'x-health-check: true' http://localhost:8080 -o response.txt; then


### PR DESCRIPTION
The `DYNO` env var is now set when running the built containers during this repo's integration tests. This means they more accurately reflect the Heroku environment, which is important since some of the getting started guides (eg Python's) use the presence of the `DYNO` env var to determine whether to enable production mode or not.

In the Python getting started guide, if DYNO is not set then the guide runs in debug mode, which means static assets can be dynamically fetched from the source, and so bypass the normal production assets serving mechanism. By setting `DYNO` the integration tests will now validate that the production assets have been generated (via the `manage.py collectstatic` command that is now automatically run by the Python CNB).

GUS-W-14144906.