### PR TITLE
Sort `[[buildpacks]]` alphabetically

### DIFF
--- a/builder-22/builder.toml
+++ b/builder-22/builder.toml
@@ -9,16 +9,8 @@ run-image = "heroku/heroku:22-cnb"
 version = "0.17.0"
 
 [[buildpacks]]
-  id = "heroku/python"
-  uri = "docker://docker.io/heroku/buildpack-python@sha256:537221283e7040997e006c90782ba93ed01edf0de705d013b474aa5ee82979fc"
-
-[[buildpacks]]
-  id = "heroku/nodejs"
-  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:d318628ddd8945ee1da9d7a43766546abafe432a8ecd75c26fef263ae7a0ff60"
-
-[[buildpacks]]
-  id = "heroku/nodejs-function"
-  uri = "docker://docker.io/heroku/buildpack-nodejs-function@sha256:b35269ffb6b0c9c6d1dce5fac447ac5a1b38e11d4877752f44f3a8ac998b9e30"
+  id = "heroku/go"
+  uri = "docker://docker.io/heroku/buildpack-go@sha256:922fe2337450d9570b4eae2aaefc805068c73053d7d7c4c4ae0da1c06bddb73e"
 
 [[buildpacks]]
   id = "heroku/java"
@@ -29,16 +21,12 @@ version = "0.17.0"
   uri = "docker://docker.io/heroku/buildpack-java-function@sha256:4cbe8d4984f70fc63e6b0fcea1b904d4246d90bbe0b9cc10ba8b73c98eda3b00"
 
 [[buildpacks]]
-  id = "heroku/scala"
-  uri = "docker://docker.io/heroku/buildpack-scala@sha256:14169e0dd1531b00f3d423787618425f1739af02ba21a9a6d88c4bc7024574cb"
+  id = "heroku/nodejs"
+  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:d318628ddd8945ee1da9d7a43766546abafe432a8ecd75c26fef263ae7a0ff60"
 
 [[buildpacks]]
-  id = "heroku/go"
-  uri = "docker://docker.io/heroku/buildpack-go@sha256:922fe2337450d9570b4eae2aaefc805068c73053d7d7c4c4ae0da1c06bddb73e"
-
-[[buildpacks]]
-  id = "heroku/ruby"
-  uri = "docker://docker.io/heroku/buildpack-ruby@sha256:fd32f123fdfa3e94eeb4ce2ad82aad353f6a3b87ac70bfebfdd30cc41927a737"
+  id = "heroku/nodejs-function"
+  uri = "docker://docker.io/heroku/buildpack-nodejs-function@sha256:b35269ffb6b0c9c6d1dce5fac447ac5a1b38e11d4877752f44f3a8ac998b9e30"
 
 [[buildpacks]]
   id = "heroku/php"
@@ -47,6 +35,18 @@ version = "0.17.0"
 [[buildpacks]]
   id = "heroku/procfile"
   uri = "docker://docker.io/heroku/procfile-cnb@sha256:ea7219d4bb50196b4f292c9aae397b17255c59a243d7408535d2a03a5cd2b040"
+
+[[buildpacks]]
+  id = "heroku/python"
+  uri = "docker://docker.io/heroku/buildpack-python@sha256:537221283e7040997e006c90782ba93ed01edf0de705d013b474aa5ee82979fc"
+
+[[buildpacks]]
+  id = "heroku/ruby"
+  uri = "docker://docker.io/heroku/buildpack-ruby@sha256:fd32f123fdfa3e94eeb4ce2ad82aad353f6a3b87ac70bfebfdd30cc41927a737"
+
+[[buildpacks]]
+  id = "heroku/scala"
+  uri = "docker://docker.io/heroku/buildpack-scala@sha256:14169e0dd1531b00f3d423787618425f1739af02ba21a9a6d88c4bc7024574cb"
 
 [[order]]
   [[order.group]]

--- a/builder-classic-22/builder.toml
+++ b/builder-classic-22/builder.toml
@@ -13,16 +13,16 @@ version = "0.17.0"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/clojure?version=0.0.0&name=Clojure"
 
 [[buildpacks]]
+  id = "heroku/go"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.0.0&name=Go"
+
+[[buildpacks]]
   id = "heroku/gradle"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle?version=0.0.0&name=Gradle"
 
 [[buildpacks]]
   id = "heroku/java"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/java?version=0.0.0&name=Java"
-
-[[buildpacks]]
-  id = "heroku/go"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.0.0&name=Go"
 
 [[buildpacks]]
   id = "heroku/nodejs"

--- a/buildpacks-20/builder.toml
+++ b/buildpacks-20/builder.toml
@@ -9,20 +9,24 @@ run-image = "heroku/heroku:20-cnb"
 version = "0.17.0"
 
 [[buildpacks]]
-  id = "heroku/java"
-  uri = "docker://docker.io/heroku/buildpack-java@sha256:3b69171e416c8062b3caefc97c206cd006a197773e380d09cb7f704a10147dee"
-
-[[buildpacks]]
-  id = "heroku/scala"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/scala?version=0.0.0&name=Scala"
+  id = "heroku/go"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.0.0&name=Go"
 
 [[buildpacks]]
   id = "heroku/gradle"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/gradle?version=0.0.0&name=Gradle"
 
 [[buildpacks]]
-  id = "heroku/ruby"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/ruby?version=0.0.0&name=Ruby"
+  id = "heroku/java"
+  uri = "docker://docker.io/heroku/buildpack-java@sha256:3b69171e416c8062b3caefc97c206cd006a197773e380d09cb7f704a10147dee"
+
+[[buildpacks]]
+  id = "heroku/nodejs"
+  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:d318628ddd8945ee1da9d7a43766546abafe432a8ecd75c26fef263ae7a0ff60"
+
+[[buildpacks]]
+  id = "heroku/php"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.0.0&name=PHP"
 
 [[buildpacks]]
   id = "heroku/procfile"
@@ -33,16 +37,12 @@ version = "0.17.0"
   uri = "https://cnb-shim.herokuapp.com/v1/heroku/python?version=0.0.0&name=Python"
 
 [[buildpacks]]
-  id = "heroku/php"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/php?version=0.0.0&name=PHP"
+  id = "heroku/ruby"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/ruby?version=0.0.0&name=Ruby"
 
 [[buildpacks]]
-  id = "heroku/go"
-  uri = "https://cnb-shim.herokuapp.com/v1/heroku/go?version=0.0.0&name=Go"
-
-[[buildpacks]]
-  id = "heroku/nodejs"
-  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:d318628ddd8945ee1da9d7a43766546abafe432a8ecd75c26fef263ae7a0ff60"
+  id = "heroku/scala"
+  uri = "https://cnb-shim.herokuapp.com/v1/heroku/scala?version=0.0.0&name=Scala"
 
 [[order]]
   [[order.group]]


### PR DESCRIPTION
In upcoming PRs I'll be adding new image variants. Sorting the list of buildpacks/URIs will make it easier to diff the included buildpacks in each builder.

This change is a no-op for the created builder itself - the detection `[[order]]` has remained unchanged.