### PR TITLE
Skip registry login if not publishing to that specific registry

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -157,8 +157,10 @@ jobs:
       - name: Load Docker images into the Docker daemon
         run: zstd -dc --long=31 images.tar.zst | docker load
       - name: Log into Docker Hub
+        if: matrix.tag_public != ''
         run: echo "${{ secrets.DOCKER_HUB_TOKEN }}" | docker login -u ${{ secrets.DOCKER_HUB_USER }} --password-stdin
-      - name: Log into additional registry
+      - name: Log into internal registry
+        if: matrix.tag_private != ''
         run: |
           export REGISTRY_TOKEN=$(curl -f -X POST ${{ secrets.SERVICE_TOKEN_ENDPOINT }} -d "{\"username\":\"${{ secrets.SERVICE_TOKEN_USER_NAME }}\", \"password\":\"${{ secrets.SERVICE_TOKEN_PASSWORD }}\"}" -s --retry 3 | jq -r ".raw_id_token")
           echo "$REGISTRY_TOKEN" | docker login ${{ secrets.REGISTRY_HOST }} -u "${{ secrets.REGISTRY_USER }}" --password-stdin


### PR DESCRIPTION
When new builder images are published on main, they can be published to two different registries:
1. The public Docker repo on Docker Hub
2. A private internal registry

Previously we'd always log into both registries, even if that particular job was only publishing to one of the two registries.

Several of our images are already only published to one of the two registries, and soon virtually all of them will be (as part of upcoming PRs to add new image variants) - meaning it makes even more sense to skip login if it's not needed.