### PR TITLE
Add a Salesforce Functions builder variant

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["buildpacks-20", "builder-classic-22", "builder-22"]
+        builder: ["buildpacks-20", "builder-classic-22", "builder-22", "salesforce-functions"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -39,9 +39,11 @@ jobs:
       # We manually compress the archive rather than relying upon actions/cache's compression, since
       # it ends up being faster both in this job and also later when the images are consumed.
       - name: Export Docker images from the Docker daemon
-        env:
-          BUILDER: ${{ matrix.builder }}
-        run: docker save ${{ matrix.builder }} heroku/heroku:${BUILDER##*-}-cnb | zstd -T0 --long=31 -o images.tar.zst
+        # Using sed rather than yq until this yq bug is fixed:
+        # https://github.com/mikefarah/yq/issues/1758
+        run: |
+          RUN_IMAGE_TAG=$(sed --quiet --regexp-extended --expression 's/run-image\s*=\s*"(.+)"/\1/p' ${{ matrix.builder }}/builder.toml)
+          docker save ${{ matrix.builder }} ${RUN_IMAGE_TAG} | zstd -T0 --long=31 -o images.tar.zst
       # We use a cache here rather than artifacts because it's 4x faster and we
       # don't need the builder archive outside of this workflow run anyway.
       - name: Save Docker images to the cache
@@ -102,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["builder-22"]
+        builder: ["builder-22", "salesforce-functions"]
         language: ["java", "javascript", "typescript"]
     steps:
       - name: Checkout
@@ -152,6 +154,8 @@ jobs:
           - builder: builder-22
             tag_public: heroku/builder:22
             tag_private: heroku-22:builder
+          - builder: salesforce-functions
+            tag_private: heroku-22:builder-functions
     steps:
       - name: Restore Docker images from the cache
         uses: actions/cache/restore@v3

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ build:
 	@pack builder create heroku/buildpacks:20 --config buildpacks-20/builder.toml --pull-policy always
 	@pack builder create heroku/builder:22 --config builder-22/builder.toml --pull-policy always
 	@pack builder create heroku/builder-classic:22 --config builder-classic-22/builder.toml --pull-policy always
+	@pack builder create salesforce-functions --config salesforce-functions/builder.toml --pull-policy always
 
+# The salesforce-functions image isn't published to Docker Hub, so is intentionally absent here.
 publish: build
 	@docker push heroku/buildpacks:20
 	@docker push heroku/builder:22

--- a/salesforce-functions/builder.toml
+++ b/salesforce-functions/builder.toml
@@ -1,0 +1,27 @@
+description = "Internal builder image for Salesforce Functions"
+
+[stack]
+id = "heroku-22"
+build-image = "heroku/heroku:22-cnb-build"
+run-image = "heroku/heroku:22-cnb"
+
+[lifecycle]
+version = "0.17.1"
+
+[[buildpacks]]
+  id = "heroku/java-function"
+  uri = "docker://docker.io/heroku/buildpack-java-function@sha256:4cbe8d4984f70fc63e6b0fcea1b904d4246d90bbe0b9cc10ba8b73c98eda3b00"
+
+[[buildpacks]]
+  id = "heroku/nodejs-function"
+  uri = "docker://docker.io/heroku/buildpack-nodejs-function@sha256:69d61df4e1805055fcf2911e75f5fed59b02292f2bda7c78b6f891e8d8cd00f3"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/nodejs-function"
+    version = "1.1.6"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/java-function"
+    version = "3.2.0"


### PR DESCRIPTION
We want to move Salesforce Functions buildpacks to their own builder image variant to more cleanly separate the two use cases (particularly given that Salesforce Functions is now deprecated), and prevent a number of issues (such as builds on the functions build system being able to pass detection even when the match against a non-functions buildpack).

For more details, see:
https://salesforce.quip.com/MoDFAX3MEf8b

The first stage of this is to create the new builder image variant.

This new variant is only being published to the internal private registry, since it's only being used by Kodon (the SF CLI no longer supports using containers to run functions) so doesn't need to be available on Docker Hub.

Once it's released, we can then switch Kodon to using the new tag, deploy Kodon to all functions spaces, and then finally remove the functions buildpacks from `heroku/builder:22`.

We'll also need to adjust the CNB release automation so that it updates the new image variant too:
https://github.com/heroku/languages-github-actions/blob/8f1d3319996df5ec9eb3b4c9c7c0d5de78fa9dba/.github/workflows/_buildpacks-release.yml#L315

GUS-W-14179967.