### PR TITLE
Set an explicit GitHub Actions shell

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -11,6 +11,13 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    # Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too, rather
+    # than only error on exit. This is important for UX since this workflow uses pipes. See:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    shell: bash
+
 jobs:
 
   create:


### PR DESCRIPTION
Setting an explicit bash shell ensures GitHub Actions enables pipefail mode too, rather than only error on exit (due to GitHub Actions slightly counter-intuitive choice of settings):
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell

This is important for UX since this workflow uses pipes.

For example, without this change, if the `docker save` command here fails, then the piping to zstd otherwise continues, resulting in an empty exported images archive that will only fail much later in the build when the archive is `docker load`ed:
https://github.com/heroku/builder/actions/runs/6303703122/job/17113579563?pr=392#step:5:7

This shell is set globally, to avoid needing to specify it for every job or run command:
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun

GUS-W-14181209.