### PR TITLE
Add `heroku/builder:20`

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["buildpacks-20", "builder-classic-22", "builder-22", "salesforce-functions"]
+        builder: ["buildpacks-20", "builder-classic-22", "builder-20", "builder-22", "salesforce-functions"]
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        builder: ["buildpacks-20", "builder-classic-22", "builder-22"]
+        builder: ["buildpacks-20", "builder-classic-22", "builder-20", "builder-22"]
         language: ["go", "gradle", "java", "node-js", "php", "python", "ruby", "scala", "typescript"]
         include:
           - builder: builder-classic-22
@@ -151,6 +151,8 @@ jobs:
             tag_private: heroku-20:builder
           - builder: builder-classic-22
             tag_public: heroku/builder-classic:22
+          - builder: builder-20
+            tag_public: heroku/builder:20
           - builder: builder-22
             tag_public: heroku/builder:22
             tag_private: heroku-22:builder

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL=/bin/bash -o pipefail
 
 build:
 	@pack builder create heroku/buildpacks:20 --config buildpacks-20/builder.toml --pull-policy always
+	@pack builder create heroku/builder:20 --config builder-20/builder.toml --pull-policy always
 	@pack builder create heroku/builder:22 --config builder-22/builder.toml --pull-policy always
 	@pack builder create heroku/builder-classic:22 --config builder-classic-22/builder.toml --pull-policy always
 	@pack builder create salesforce-functions --config salesforce-functions/builder.toml --pull-policy always
@@ -11,5 +12,6 @@ build:
 # The salesforce-functions image isn't published to Docker Hub, so is intentionally absent here.
 publish: build
 	@docker push heroku/buildpacks:20
+	@docker push heroku/builder:20
 	@docker push heroku/builder:22
 	@docker push heroku/builder-classic:22

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The builder images use Heroku's [stack images](https://github.com/heroku/stack-i
 |-----------------------------------------------------|---------------------------------------------|-------------|
 | [`heroku/buildpacks:18`][buildpacks-tags]           | [`heroku/heroku:18-cnb-build`][heroku-tags] | End-of-life |
 | [`heroku/buildpacks:20`][buildpacks-tags]           | [`heroku/heroku:20-cnb-build`][heroku-tags] | Available   |
+| [`heroku/builder:20`][builder-tags]                 | [`heroku/heroku:20-cnb-build`][heroku-tags] | Available   |
 | [`heroku/builder:22`][builder-tags]                 | [`heroku/heroku:22-cnb-build`][heroku-tags] | Recommended |
 | [`heroku/builder-classic:22`][builder-classic-tags] | [`heroku/heroku:22-cnb-build`][heroku-tags] | Available   |
 

--- a/builder-20/builder.toml
+++ b/builder-20/builder.toml
@@ -1,0 +1,104 @@
+description = "Base builder for Heroku-20 stack, based on ubuntu:20.04 base image"
+
+[stack]
+id = "heroku-20"
+build-image = "heroku/heroku:20-cnb-build"
+run-image = "heroku/heroku:20-cnb"
+
+[lifecycle]
+version = "0.17.1"
+
+[[buildpacks]]
+  id = "heroku/go"
+  uri = "docker://docker.io/heroku/buildpack-go@sha256:922fe2337450d9570b4eae2aaefc805068c73053d7d7c4c4ae0da1c06bddb73e"
+
+[[buildpacks]]
+  id = "heroku/java"
+  uri = "docker://docker.io/heroku/buildpack-java@sha256:3b69171e416c8062b3caefc97c206cd006a197773e380d09cb7f704a10147dee"
+
+[[buildpacks]]
+  id = "heroku/nodejs"
+  uri = "docker://docker.io/heroku/buildpack-nodejs@sha256:5000a0f8ca2f440bedc24dd1a75dd20c60ffb8ff1708b7490d67aa290f280606"
+
+[[buildpacks]]
+  id = "heroku/php"
+  uri = "docker://docker.io/heroku/buildpack-php@sha256:19e44139b850b3b9040f21d436ec693f0dff82e931bbff500e9876f4febacd0e"
+
+[[buildpacks]]
+  id = "heroku/procfile"
+  uri = "docker://docker.io/heroku/procfile-cnb@sha256:ea7219d4bb50196b4f292c9aae397b17255c59a243d7408535d2a03a5cd2b040"
+
+[[buildpacks]]
+  id = "heroku/python"
+  uri = "docker://docker.io/heroku/buildpack-python@sha256:537221283e7040997e006c90782ba93ed01edf0de705d013b474aa5ee82979fc"
+
+[[buildpacks]]
+  id = "heroku/ruby"
+  uri = "docker://docker.io/heroku/buildpack-ruby@sha256:fd32f123fdfa3e94eeb4ce2ad82aad353f6a3b87ac70bfebfdd30cc41927a737"
+
+[[buildpacks]]
+  id = "heroku/scala"
+  uri = "docker://docker.io/heroku/buildpack-scala@sha256:14169e0dd1531b00f3d423787618425f1739af02ba21a9a6d88c4bc7024574cb"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/python"
+    version = "0.7.0"
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "2.0.1"
+    optional = true
+
+[[order]]
+  [[order.group]]
+    id = "heroku/nodejs-engine"
+    version = "1.1.6"
+    optional = true
+  [[order.group]]
+    id = "heroku/nodejs-yarn"
+    version = "1.1.6"
+    optional = true
+  [[order.group]]
+    id = "heroku/jvm"
+    version = "3.2.0"
+    optional = true
+  [[order.group]]
+    id = "heroku/ruby"
+    version = "2.0.1"
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "2.0.1"
+    optional = true
+
+[[order]]
+  [[order.group]]
+    id = "heroku/nodejs"
+    version = "1.1.6"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/java"
+    version = "3.2.0"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/scala"
+    version = "3.2.0"
+
+[[order]]
+  [[order.group]]
+    id = "heroku/go"
+    version = "0.1.9"
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "2.0.1"
+    optional = true
+
+[[order]]
+  [[order.group]]
+    id = "heroku/php"
+    version = "0.1.1"
+  [[order.group]]
+    id = "heroku/procfile"
+    version = "2.0.1"
+    optional = true


### PR DESCRIPTION
The builder images in this repository fall into two main groups:
1. The legacy `heroku/buildpacks:*` builder namespace that use a mixture of native CNBs and shimmed classic buildpacks.
2. The newer `heroku/builder:*` builder namespace that uses only native (non-shimmed) CNBs.

Previously, if someone wanted to use the newer builder image type they had to use `heroku/builder:22` which is based on the Heroku-22 stack (Ubuntu 22.04). 

Now, if someone needs to use Heroku-20  (Ubuntu 20.04), they can do so via a new `heroku/builder:20` image, rather than needing to fall back to the older `heroku/buildpacks:20` image and its shimmed classic buildpacks.

This will make it easier for us to deprecate `heroku/buildpacks:20` in future PRs, since there will now be an easier upgrade paths for users that need eg older language runtime versions of Python/Ruby/PHP etc.

The new `heroku/builder:20` builder image variant is identical to `heroku/builder:22`, except:
- it uses Heroku-20 based run/build-images (instead of Heroku-22 based)
- it doesn't include the java/node.js functions buildpacks (which are due to be removed from `heroku/builder:22` soon in favour of the newly added internal Salesforce Functions image variant).

When this is merged, we'll also need to:
- add the new CI jobs to the branch protection required CI jobs list
- adjust the CNB release automation so that it updates this new builder too (heroku/languages-github-actions#144)

For more details, see:
https://salesforce.quip.com/0JtbAYiWZYk6

GUS-W-14184901.